### PR TITLE
feat: 메뉴 API 

### DIFF
--- a/src/main/java/com/ourMenu/backend/domain/menu/api/MenuApiController.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/api/MenuApiController.java
@@ -1,0 +1,138 @@
+package com.ourMenu.backend.domain.menu.api;
+
+import com.ourMenu.backend.domain.menu.application.MenuService;
+import com.ourMenu.backend.domain.menu.domain.Menu;
+import com.ourMenu.backend.domain.menu.dto.request.PatchMenuRequest;
+import com.ourMenu.backend.domain.menu.dto.response.PatchMenuResponse;
+import com.ourMenu.backend.domain.menu.dto.request.PostMenuRequest;
+import com.ourMenu.backend.domain.menu.dto.response.PostMenuResponse;
+import com.ourMenu.backend.domain.menu.dto.response.GetMenuResponse;
+import com.ourMenu.backend.global.common.ApiResponse;
+import com.ourMenu.backend.global.util.ApiUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/menu")
+@RequiredArgsConstructor
+public class MenuApiController {
+
+    private final MenuService menuService;
+
+    /*
+    메뉴 생성
+     */
+    @PostMapping("")
+    public ApiResponse<PostMenuResponse> saveMenu(@RequestBody PostMenuRequest postMenuRequest) {
+        Menu menu = new Menu();
+        menu.setTitle(postMenuRequest.getTitle());
+        menu.setPrice(postMenuRequest.getPrice());
+        menu.setImgUrl(postMenuRequest.getImgUrl());
+        menu.setMemo(postMenuRequest.getMemo());
+
+        Menu savedMenu = menuService.createMenu(menu);
+        PostMenuResponse postMenuResponse = new PostMenuResponse();
+        postMenuResponse.setId(savedMenu.getId());
+
+        return ApiUtils.success(postMenuResponse);
+    }
+
+    /*
+    ID를 통한 메뉴 조회
+     */
+    @GetMapping("/{id}")
+    public ApiResponse<GetMenuResponse> getMenuById(@PathVariable Long id) {
+        Menu menu = menuService.getMenuById(id);
+
+        GetMenuResponse response = new GetMenuResponse();
+        response.setId(menu.getId());
+        response.setTitle(menu.getTitle());
+        response.setPrice(menu.getPrice());
+        response.setImgUrl(menu.getImgUrl());
+        response.setStatus(menu.getStatus());
+        response.setCreatedAt(menu.getCreatedAt());
+        response.setModifiedAt(menu.getModifiedAt());
+        response.setMemo(menu.getMemo());
+
+        return ApiUtils.success(response);
+    }
+
+    @GetMapping("")
+    public ApiResponse<List<GetMenuResponse>> getAllMenu() {
+        List<Menu> menuList = menuService.getAllMenus();
+        List<GetMenuResponse> responseList = menuList.stream().map(menu -> {
+            GetMenuResponse response = new GetMenuResponse();
+            response.setId(menu.getId());
+            response.setTitle(menu.getTitle());
+            response.setPrice(menu.getPrice());
+            response.setImgUrl(menu.getImgUrl());
+            response.setMemo(menu.getMemo());
+            response.setStatus(menu.getStatus());
+            response.setCreatedAt(menu.getCreatedAt());
+            response.setModifiedAt(menu.getModifiedAt());
+            return response;
+        }).collect(Collectors.toList());
+
+        return ApiUtils.success(responseList);
+    }
+
+    /*
+    메뉴 삭제
+     */
+    @DeleteMapping("/{id}")
+    public ApiResponse<String> removeMenu(@PathVariable Long id){
+        menuService.deleteMenu(id);
+        return ApiUtils.success("OK");
+    }
+
+//    @PatchMapping("/{id}")
+//    public ApiResponse<PatchMenuResponse> updateMenu(@PathVariable Long id, @RequestParam String title,
+//                                                     @RequestParam String imgUrl,
+//                                                     @RequestParam int price, @RequestParam String memo){
+//        Menu menu = new Menu();
+//        menu.setTitle(title);
+//        menu.setImgUrl(imgUrl);
+//        menu.setPrice(price);
+//        menu.setMemo(memo);
+//
+//        Menu updatedMenu = menuService.updateMenu(id, menu);
+//
+//        PatchMenuResponse response = new PatchMenuResponse();
+//        response.setId(updatedMenu.getId());
+//        response.setTitle(updatedMenu.getTitle());
+//        response.setImgUrl(updatedMenu.getImgUrl());
+//        response.setPrice(updatedMenu.getPrice());
+//        response.setMemo(updatedMenu.getMemo());
+//        response.setCreatedAt(updatedMenu.getCreatedAt());
+//        response.setModifiedAt(updatedMenu.getModifiedAt());
+//        response.setStatus(updatedMenu.getStatus());
+//
+//
+//        return ApiUtils.success(response);
+//    }
+
+    /*
+    메뉴 업데이트
+     */
+    @PatchMapping("/{id}")
+    public ApiResponse<PatchMenuResponse> updateMenu(@PathVariable Long id, @RequestBody PatchMenuRequest patchMenuRequest){
+        Menu updatedMenu = menuService.updateMenu(id, patchMenuRequest);
+
+        PatchMenuResponse response = new PatchMenuResponse();
+        response.setId(updatedMenu.getId());
+        response.setTitle(updatedMenu.getTitle());
+        response.setImgUrl(updatedMenu.getImgUrl());
+        response.setPrice(updatedMenu.getPrice());
+        response.setMemo(updatedMenu.getMemo());
+        response.setCreatedAt(updatedMenu.getCreatedAt());
+        response.setModifiedAt(updatedMenu.getModifiedAt());
+        response.setStatus(updatedMenu.getStatus());
+
+
+        return ApiUtils.success(response);
+    }
+
+}

--- a/src/main/java/com/ourMenu/backend/domain/menu/application/MenuService.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/application/MenuService.java
@@ -1,8 +1,8 @@
-package com.ourMenu.backend.menu.application;
+package com.ourMenu.backend.domain.menu.application;
 
-import com.ourMenu.backend.menu.dao.MenuRepository;
-import com.ourMenu.backend.menu.domain.Menu;
-import com.ourMenu.backend.menu.domain.MenuStatus;
+import com.ourMenu.backend.domain.menu.domain.MenuStatus;
+import com.ourMenu.backend.domain.menu.dao.MenuRepository;
+import com.ourMenu.backend.domain.menu.domain.Menu;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/ourMenu/backend/domain/menu/application/MenuService.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/application/MenuService.java
@@ -3,6 +3,7 @@ package com.ourMenu.backend.domain.menu.application;
 import com.ourMenu.backend.domain.menu.domain.MenuStatus;
 import com.ourMenu.backend.domain.menu.dao.MenuRepository;
 import com.ourMenu.backend.domain.menu.domain.Menu;
+import com.ourMenu.backend.domain.menu.dto.request.PatchMenuRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -51,6 +52,30 @@ public class MenuService {
         } else {
             return null;
         }
+    }
+
+    /*
+    Request를 통한 메뉴 업데이트
+     */
+    @Transactional
+    public Menu updateMenu(Long id, PatchMenuRequest patchMenuRequest) {
+        Menu menu = menuRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Menu not found"));
+
+        if (patchMenuRequest.getTitle() != null) {
+            menu.setTitle(patchMenuRequest.getTitle());
+        }
+        if (patchMenuRequest.getImgUrl() != null) {
+            menu.setImgUrl(patchMenuRequest.getImgUrl());
+        }
+        if (patchMenuRequest.getPrice() != 0) { // 가격이 0이 아닌 경우에만 업데이트
+            menu.setPrice(patchMenuRequest.getPrice());
+        }
+        if (patchMenuRequest.getMemo() != null) {
+            menu.setMemo(patchMenuRequest.getMemo());
+        }
+
+        return menuRepository.save(menu);
     }
 
     // 메뉴 삭제 *

--- a/src/main/java/com/ourMenu/backend/domain/menu/dao/MenuRepository.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/dao/MenuRepository.java
@@ -1,6 +1,6 @@
-package com.ourMenu.backend.menu.dao;
+package com.ourMenu.backend.domain.menu.dao;
 
-import com.ourMenu.backend.menu.domain.Menu;
+import com.ourMenu.backend.domain.menu.domain.Menu;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MenuRepository extends JpaRepository<Menu, Long> {

--- a/src/main/java/com/ourMenu/backend/domain/menu/domain/Menu.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/domain/Menu.java
@@ -1,4 +1,4 @@
-package com.ourMenu.backend.menu.domain;
+package com.ourMenu.backend.domain.menu.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;

--- a/src/main/java/com/ourMenu/backend/domain/menu/domain/Menu.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/domain/Menu.java
@@ -1,17 +1,16 @@
 package com.ourMenu.backend.domain.menu.domain;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
-import java.security.Timestamp;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Getter
 @Setter
-
 public class Menu {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,13 +25,24 @@ public class Menu {
     private String ImgUrl;
 
     @Enumerated(EnumType.STRING)
-    private MenuStatus status;
+    private MenuStatus status = MenuStatus.CREATED;
 
     @OneToMany(mappedBy = "menu")
     private List<MenuMenuList> menuMenuLists = new ArrayList<>();
 
-    private Timestamp createdAt;
-    private Timestamp modifiedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
     private String memo;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.status = (this.status == null) ? MenuStatus.CREATED : this.status;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.modifiedAt = LocalDateTime.now();
+    }
 
 }

--- a/src/main/java/com/ourMenu/backend/domain/menu/domain/MenuMenuList.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/domain/MenuMenuList.java
@@ -1,6 +1,6 @@
-package com.ourMenu.backend.menu.domain;
+package com.ourMenu.backend.domain.menu.domain;
 
-import com.ourMenu.backend.menulist.domain.MenuList;
+import com.ourMenu.backend.domain.menulist.domain.MenuList;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/ourMenu/backend/domain/menu/domain/MenuStatus.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/domain/MenuStatus.java
@@ -1,4 +1,4 @@
-package com.ourMenu.backend.menu.domain;
+package com.ourMenu.backend.domain.menu.domain;
 
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Embedded;

--- a/src/main/java/com/ourMenu/backend/domain/menu/dto/request/PatchMenuRequest.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/dto/request/PatchMenuRequest.java
@@ -1,0 +1,11 @@
+package com.ourMenu.backend.domain.menu.dto.request;
+
+import lombok.Data;
+
+@Data
+public class PatchMenuRequest {
+    private String title;
+    private int price;
+    private String ImgUrl;
+    private String memo;
+}

--- a/src/main/java/com/ourMenu/backend/domain/menu/dto/request/PostMenuRequest.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/dto/request/PostMenuRequest.java
@@ -1,0 +1,20 @@
+package com.ourMenu.backend.domain.menu.dto.request;
+
+import com.ourMenu.backend.domain.menu.domain.MenuStatus;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.security.Timestamp;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostMenuRequest {
+
+    private String title;
+    private int price;
+    private String ImgUrl;
+    private String memo;
+
+}

--- a/src/main/java/com/ourMenu/backend/domain/menu/dto/response/GetMenuResponse.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/dto/response/GetMenuResponse.java
@@ -1,0 +1,19 @@
+package com.ourMenu.backend.domain.menu.dto.response;
+
+import com.ourMenu.backend.domain.menu.domain.MenuStatus;
+import lombok.Data;
+
+import java.security.Timestamp;
+import java.time.LocalDateTime;
+
+@Data
+public class GetMenuResponse {
+    private Long id;
+    private String title;
+    private int price;
+    private String imgUrl;
+    private MenuStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+    private String memo;
+}

--- a/src/main/java/com/ourMenu/backend/domain/menu/dto/response/PatchMenuResponse.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/dto/response/PatchMenuResponse.java
@@ -1,0 +1,18 @@
+package com.ourMenu.backend.domain.menu.dto.response;
+
+import com.ourMenu.backend.domain.menu.domain.MenuStatus;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class PatchMenuResponse {
+    private Long id;
+    private String title;
+    private int price;
+    private String imgUrl;
+    private MenuStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+    private String memo;
+}

--- a/src/main/java/com/ourMenu/backend/domain/menu/dto/response/PostMenuResponse.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/dto/response/PostMenuResponse.java
@@ -1,0 +1,8 @@
+package com.ourMenu.backend.domain.menu.dto.response;
+
+import lombok.Data;
+
+@Data
+public class PostMenuResponse {
+    private Long id;
+}

--- a/src/main/java/com/ourMenu/backend/domain/menulist/application/MenuListService.java
+++ b/src/main/java/com/ourMenu/backend/domain/menulist/application/MenuListService.java
@@ -1,18 +1,18 @@
-package com.ourMenu.backend.menulist.application;
+package com.ourMenu.backend.domain.menulist.application;
 
-import com.ourMenu.backend.menu.dao.MenuRepository;
-import com.ourMenu.backend.menu.domain.Menu;
-import com.ourMenu.backend.menu.domain.MenuMenuList;
-import com.ourMenu.backend.menulist.domain.MenuList;
-import com.ourMenu.backend.menulist.domain.MenuListStatus;
-import com.ourMenu.backend.menulist.dao.MenuListRepository;
+import com.ourMenu.backend.domain.menu.dao.MenuRepository;
+import com.ourMenu.backend.domain.menu.domain.Menu;
+import com.ourMenu.backend.domain.menu.domain.MenuMenuList;
+import com.ourMenu.backend.domain.menulist.dao.MenuListRepository;
+import com.ourMenu.backend.domain.menulist.domain.MenuList;
+import com.ourMenu.backend.domain.menulist.domain.MenuListStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static com.ourMenu.backend.menu.domain.MenuMenuList.createMenuMenuList;
+import static com.ourMenu.backend.domain.menu.domain.MenuMenuList.createMenuMenuList;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/ourMenu/backend/domain/menulist/dao/MenuListRepository.java
+++ b/src/main/java/com/ourMenu/backend/domain/menulist/dao/MenuListRepository.java
@@ -1,6 +1,6 @@
-package com.ourMenu.backend.menulist.dao;
+package com.ourMenu.backend.domain.menulist.dao;
 
-import com.ourMenu.backend.menulist.domain.MenuList;
+import com.ourMenu.backend.domain.menulist.domain.MenuList;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MenuListRepository extends JpaRepository<MenuList, Long> {

--- a/src/main/java/com/ourMenu/backend/domain/menulist/domain/MenuList.java
+++ b/src/main/java/com/ourMenu/backend/domain/menulist/domain/MenuList.java
@@ -1,6 +1,6 @@
-package com.ourMenu.backend.menulist.domain;
+package com.ourMenu.backend.domain.menulist.domain;
 
-import com.ourMenu.backend.menu.domain.MenuMenuList;
+import com.ourMenu.backend.domain.menu.domain.MenuMenuList;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/ourMenu/backend/domain/menulist/domain/MenuListStatus.java
+++ b/src/main/java/com/ourMenu/backend/domain/menulist/domain/MenuListStatus.java
@@ -1,4 +1,4 @@
-package com.ourMenu.backend.menulist.domain;
+package com.ourMenu.backend.domain.menulist.domain;
 
 public enum MenuListStatus {
     CREATED,

--- a/src/test/java/com/ourMenu/backend/ci/menu/application/MenuServiceTest.java
+++ b/src/test/java/com/ourMenu/backend/ci/menu/application/MenuServiceTest.java
@@ -1,9 +1,9 @@
 package com.ourMenu.backend.ci.menu.application;
 
-import com.ourMenu.backend.menu.application.MenuService;
-import com.ourMenu.backend.menu.dao.MenuRepository;
-import com.ourMenu.backend.menu.domain.Menu;
-import com.ourMenu.backend.menu.domain.MenuStatus;
+import com.ourMenu.backend.domain.menu.application.MenuService;
+import com.ourMenu.backend.domain.menu.dao.MenuRepository;
+import com.ourMenu.backend.domain.menu.domain.Menu;
+import com.ourMenu.backend.domain.menu.domain.MenuStatus;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/ourMenu/backend/ci/menulist/application/MenuListServiceTest.java
+++ b/src/test/java/com/ourMenu/backend/ci/menulist/application/MenuListServiceTest.java
@@ -1,13 +1,13 @@
 package com.ourMenu.backend.ci.menulist.application;
 
-import com.ourMenu.backend.menu.application.MenuService;
-import com.ourMenu.backend.menu.dao.MenuRepository;
-import com.ourMenu.backend.menu.domain.Menu;
-import com.ourMenu.backend.menu.domain.MenuStatus;
+import com.ourMenu.backend.domain.menu.application.MenuService;
+import com.ourMenu.backend.domain.menu.dao.MenuRepository;
+import com.ourMenu.backend.domain.menu.domain.Menu;
+import com.ourMenu.backend.domain.menu.domain.MenuStatus;
 
-import com.ourMenu.backend.menulist.application.MenuListService;
-import com.ourMenu.backend.menulist.dao.MenuListRepository;
-import com.ourMenu.backend.menulist.domain.MenuList;
+import com.ourMenu.backend.domain.menulist.application.MenuListService;
+import com.ourMenu.backend.domain.menulist.dao.MenuListRepository;
+import com.ourMenu.backend.domain.menulist.domain.MenuList;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
### ✏️ 작업 개요
메뉴 Entity API 구현

### ⛳ 작업 분류
- [x] 작업1 DTO 생성
- [x] 작업2 API 구현
- [x] 작업3 메뉴 등록 및 변경 시 createdAt 및 modifiedAt 반영

### 🔨 작업 상세 내용
  1. Http 메서드에 해당하는 Request 및 Response DTO 클래스 생성했습니다.
  2. POST, GET(단건조회, 전체조회), PATCH, DELETE API 구현했습니다.
  3. 메뉴 등록 및 변경 시 createdAt 및 modifiedAt 반영했습니다.
  4. 기존에 MenuService의 매개변수를 Menu로 받는 updateMenu 대신 PatchMenuRequest를 매개변수로 받는 updateMenu 메서드를 작성하였습니다.

### 💡 생각해볼 문제

1. Controller에서의 무분별한 setter 사용을 하고있는데, 추후에 Builder 등과 같은 방식을 사용하여 리팩토링을 해야할 것 같습니다.
2. 메뉴 추가 및 수정에서  태그와 아이콘, 그리고 가게의 이름, 주소, 영업시간 등을 입력받고 있는데 이에 대한 반영이 되어있지 않습니다.(ERD 검토 및 확정 필요)
3. Controller에서 예외처리를 아직 구현하지 않았습니다.