### PR TITLE
메뉴판 API 구현 및 메뉴 리팩토링

### DIFF
--- a/src/main/java/com/ourMenu/backend/domain/menu/api/MenuApiController.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/api/MenuApiController.java
@@ -3,10 +3,9 @@ package com.ourMenu.backend.domain.menu.api;
 import com.ourMenu.backend.domain.menu.application.MenuService;
 import com.ourMenu.backend.domain.menu.domain.Menu;
 import com.ourMenu.backend.domain.menu.dto.request.PatchMenuRequest;
-import com.ourMenu.backend.domain.menu.dto.response.PatchMenuResponse;
 import com.ourMenu.backend.domain.menu.dto.request.PostMenuRequest;
 import com.ourMenu.backend.domain.menu.dto.response.PostMenuResponse;
-import com.ourMenu.backend.domain.menu.dto.response.GetMenuResponse;
+import com.ourMenu.backend.domain.menu.dto.response.MenuDto;
 import com.ourMenu.backend.global.common.ApiResponse;
 import com.ourMenu.backend.global.util.ApiUtils;
 import lombok.RequiredArgsConstructor;
@@ -44,36 +43,19 @@ public class MenuApiController {
     ID를 통한 메뉴 조회
      */
     @GetMapping("/{id}")
-    public ApiResponse<GetMenuResponse> getMenuById(@PathVariable Long id) {
+    public ApiResponse<MenuDto> getMenuById(@PathVariable Long id) {
         Menu menu = menuService.getMenuById(id);
 
-        GetMenuResponse response = new GetMenuResponse();
-        response.setId(menu.getId());
-        response.setTitle(menu.getTitle());
-        response.setPrice(menu.getPrice());
-        response.setImgUrl(menu.getImgUrl());
-        response.setStatus(menu.getStatus());
-        response.setCreatedAt(menu.getCreatedAt());
-        response.setModifiedAt(menu.getModifiedAt());
-        response.setMemo(menu.getMemo());
+        MenuDto response = menuDto(menu);
 
         return ApiUtils.success(response);
     }
 
     @GetMapping("")
-    public ApiResponse<List<GetMenuResponse>> getAllMenu() {
+    public ApiResponse<List<MenuDto>> getAllMenu() {
         List<Menu> menuList = menuService.getAllMenus();
-        List<GetMenuResponse> responseList = menuList.stream().map(menu -> {
-            GetMenuResponse response = new GetMenuResponse();
-            response.setId(menu.getId());
-            response.setTitle(menu.getTitle());
-            response.setPrice(menu.getPrice());
-            response.setImgUrl(menu.getImgUrl());
-            response.setMemo(menu.getMemo());
-            response.setStatus(menu.getStatus());
-            response.setCreatedAt(menu.getCreatedAt());
-            response.setModifiedAt(menu.getModifiedAt());
-            return response;
+        List<MenuDto> responseList = menuList.stream().map(menu -> {
+            return menuDto(menu);
         }).collect(Collectors.toList());
 
         return ApiUtils.success(responseList);
@@ -118,21 +100,24 @@ public class MenuApiController {
     메뉴 업데이트
      */
     @PatchMapping("/{id}")
-    public ApiResponse<PatchMenuResponse> updateMenu(@PathVariable Long id, @RequestBody PatchMenuRequest patchMenuRequest){
+    public ApiResponse<MenuDto> updateMenu(@PathVariable Long id, @RequestBody PatchMenuRequest patchMenuRequest){
         Menu updatedMenu = menuService.updateMenu(id, patchMenuRequest);
 
-        PatchMenuResponse response = new PatchMenuResponse();
-        response.setId(updatedMenu.getId());
-        response.setTitle(updatedMenu.getTitle());
-        response.setImgUrl(updatedMenu.getImgUrl());
-        response.setPrice(updatedMenu.getPrice());
-        response.setMemo(updatedMenu.getMemo());
-        response.setCreatedAt(updatedMenu.getCreatedAt());
-        response.setModifiedAt(updatedMenu.getModifiedAt());
-        response.setStatus(updatedMenu.getStatus());
-
-
+        MenuDto response = menuDto(updatedMenu);
         return ApiUtils.success(response);
     }
 
+
+    private static MenuDto menuDto(Menu menu) {
+        MenuDto response = new MenuDto();
+        response.setId(menu.getId());
+        response.setTitle(menu.getTitle());
+        response.setPrice(menu.getPrice());
+        response.setImgUrl(menu.getImgUrl());
+        response.setMemo(menu.getMemo());
+        response.setStatus(menu.getStatus());
+        response.setCreatedAt(menu.getCreatedAt());
+        response.setModifiedAt(menu.getModifiedAt());
+        return response;
+    }
 }

--- a/src/main/java/com/ourMenu/backend/domain/menu/api/MenuApiController.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/api/MenuApiController.java
@@ -109,15 +109,16 @@ public class MenuApiController {
 
 
     private static MenuDto menuDto(Menu menu) {
-        MenuDto response = new MenuDto();
-        response.setId(menu.getId());
-        response.setTitle(menu.getTitle());
-        response.setPrice(menu.getPrice());
-        response.setImgUrl(menu.getImgUrl());
-        response.setMemo(menu.getMemo());
-        response.setStatus(menu.getStatus());
-        response.setCreatedAt(menu.getCreatedAt());
-        response.setModifiedAt(menu.getModifiedAt());
+        MenuDto response = MenuDto.builder()
+                        .id(menu.getId())
+                .title(menu.getTitle())
+                .price(menu.getPrice())
+                .imgUrl(menu.getImgUrl())
+                .createdAt(menu.getCreatedAt())
+                .modifiedAt(menu.getModifiedAt())
+                .memo(menu.getMemo())
+                .status(menu.getStatus())
+                .build();
         return response;
     }
 }

--- a/src/main/java/com/ourMenu/backend/domain/menu/dto/response/MenuDto.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/dto/response/MenuDto.java
@@ -3,11 +3,10 @@ package com.ourMenu.backend.domain.menu.dto.response;
 import com.ourMenu.backend.domain.menu.domain.MenuStatus;
 import lombok.Data;
 
-import java.security.Timestamp;
 import java.time.LocalDateTime;
 
 @Data
-public class GetMenuResponse {
+public class MenuDto {
     private Long id;
     private String title;
     private int price;

--- a/src/main/java/com/ourMenu/backend/domain/menu/dto/response/MenuDto.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/dto/response/MenuDto.java
@@ -1,11 +1,13 @@
 package com.ourMenu.backend.domain.menu.dto.response;
 
 import com.ourMenu.backend.domain.menu.domain.MenuStatus;
+import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalDateTime;
 
 @Data
+@Builder
 public class MenuDto {
     private Long id;
     private String title;

--- a/src/main/java/com/ourMenu/backend/domain/menulist/api/MenuListApiController.java
+++ b/src/main/java/com/ourMenu/backend/domain/menulist/api/MenuListApiController.java
@@ -1,5 +1,6 @@
 package com.ourMenu.backend.domain.menulist.api;
 
+import com.ourMenu.backend.domain.menu.dto.response.MenuDto;
 import com.ourMenu.backend.domain.menulist.application.MenuListService;
 import com.ourMenu.backend.domain.menulist.domain.MenuList;
 import com.ourMenu.backend.domain.menulist.dto.request.PatchMenuListRequest;
@@ -112,7 +113,18 @@ public class MenuListApiController {
                 .imgUrl(menuList.getImgUrl())
                 .createdAt(menuList.getCreatedAt())
                 .modifiedAt(menuList.getModifiedAt())
-                .menuMenuLists(menuList.getMenuMenuLists())
+                .menus(menuList.getMenuMenuLists().stream()
+                        .map(menuMenuList -> MenuDto.builder()
+                                .id(menuMenuList.getMenu().getId())
+                                .title(menuMenuList.getMenu().getTitle())
+                                .price(menuMenuList.getMenu().getPrice())
+                                .createdAt(menuMenuList.getMenu().getCreatedAt())
+                                .modifiedAt(menuMenuList.getMenu().getModifiedAt())
+                                .memo(menuMenuList.getMenu().getMemo())
+                                .imgUrl(menuMenuList.getMenu().getImgUrl())
+                                .status(menuMenuList.getMenu().getStatus())
+                                .build())
+                        .collect(Collectors.toList()))
                 .build();
         return menuListDto;
     }

--- a/src/main/java/com/ourMenu/backend/domain/menulist/api/MenuListApiController.java
+++ b/src/main/java/com/ourMenu/backend/domain/menulist/api/MenuListApiController.java
@@ -1,0 +1,119 @@
+package com.ourMenu.backend.domain.menulist.api;
+
+import com.ourMenu.backend.domain.menulist.application.MenuListService;
+import com.ourMenu.backend.domain.menulist.domain.MenuList;
+import com.ourMenu.backend.domain.menulist.dto.request.PatchMenuListRequest;
+import com.ourMenu.backend.domain.menulist.dto.request.PostMenuListRequest;
+import com.ourMenu.backend.domain.menulist.dto.response.MenuListDto;
+import com.ourMenu.backend.domain.menulist.dto.response.PostMenuListResponse;
+import com.ourMenu.backend.global.common.ApiResponse;
+import com.ourMenu.backend.global.util.ApiUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/menuList")
+public class MenuListApiController {
+
+    private final MenuListService menuListService;
+
+    /*
+    메뉴판 등록
+     */
+    @PostMapping("")
+    public ApiResponse<PostMenuListResponse> saveMenuList(@RequestBody PostMenuListRequest postMenuListRequest) {
+        MenuList menuList = MenuList.builder()
+                .title(postMenuListRequest.getTitle())
+                .imgUrl(postMenuListRequest.getImgUrl())
+                .build();
+
+        MenuList savedMenuList = menuListService.createMenuList(menuList);
+
+        PostMenuListResponse response = PostMenuListResponse.builder()
+                .id(savedMenuList.getId())
+                .build();
+        return ApiUtils.success(response);
+    }
+
+    /*
+    메뉴판 전체 조회
+     */
+    @GetMapping("")
+    public ApiResponse<List<MenuListDto>> findAllMenuList(){
+        List<MenuList> menuLists = menuListService.getAllMenuLists();
+        List<MenuListDto> responseList = menuLists.stream().map(menuList -> {
+            return getMenuListDto(menuList);
+        }).collect(Collectors.toList());
+
+        return ApiUtils.success(responseList);
+    }
+
+    /*
+    메뉴판 단건 조회
+     */
+    @GetMapping("/{id}")
+    public ApiResponse<MenuListDto> findMenuListById(@PathVariable Long id){
+        MenuList menuList = menuListService.getMenuListById(id);
+        MenuListDto response = getMenuListDto(menuList);
+        return ApiUtils.success(response);
+    }
+
+    /*
+    메뉴판 수정(제목, 사진)
+     */
+    @PatchMapping("/{id}")
+    public ApiResponse<MenuListDto> updateMenuList(@PathVariable Long id, @RequestBody PatchMenuListRequest patchMenuListRequest){
+        MenuList menuList = menuListService.updateMenuList(id, patchMenuListRequest);
+        MenuListDto response = getMenuListDto(menuList);
+        return ApiUtils.success(response);
+    }
+
+    /*
+    메뉴판 삭제
+     */
+    @DeleteMapping("/{id}")
+    public ApiResponse<String> removeMenuList(@PathVariable Long id){
+        menuListService.deleteMenuList(id);
+        return ApiUtils.success("OK");
+    }
+
+    /*
+    메뉴판 메뉴 추가
+     */
+    @PatchMapping("")
+    public ApiResponse<MenuListDto> addMenuInMenuList(@RequestParam Long menuId, @RequestParam Long menuListId){
+        MenuList menuList = menuListService.addMenu(menuId, menuListId);
+        MenuListDto response = getMenuListDto(menuList);
+        return ApiUtils.success(response);
+    }
+
+    /*
+    메뉴판 메뉴 삭제
+     */
+    @DeleteMapping("")
+    public ApiResponse<String> removeMenuInMenuList(@RequestParam Long menuId, @RequestParam Long menuListId){
+        menuListService.deleteMenu(menuId, menuListId);
+        return ApiUtils.success("OK");
+    }
+
+
+    /*
+    Get 메서드 Response 생성 메서드
+     */
+    private static MenuListDto getMenuListDto(MenuList menuList) {
+        MenuListDto menuListDto = MenuListDto.builder()
+                .id(menuList.getId())
+                .title(menuList.getTitle())
+                .status(menuList.getStatus())
+                .imgUrl(menuList.getImgUrl())
+                .createdAt(menuList.getCreatedAt())
+                .modifiedAt(menuList.getModifiedAt())
+                .menuMenuLists(menuList.getMenuMenuLists())
+                .build();
+        return menuListDto;
+    }
+}

--- a/src/main/java/com/ourMenu/backend/domain/menulist/application/MenuListService.java
+++ b/src/main/java/com/ourMenu/backend/domain/menulist/application/MenuListService.java
@@ -6,6 +6,7 @@ import com.ourMenu.backend.domain.menu.domain.MenuMenuList;
 import com.ourMenu.backend.domain.menulist.dao.MenuListRepository;
 import com.ourMenu.backend.domain.menulist.domain.MenuList;
 import com.ourMenu.backend.domain.menulist.domain.MenuListStatus;
+import com.ourMenu.backend.domain.menulist.dto.request.PatchMenuListRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -93,6 +94,24 @@ public class MenuListService {
         } else {
             return null;
         }
+    }
+
+    /*
+    Request를 통한 메뉴판 업데이트
+     */
+    @Transactional
+    public MenuList updateMenuList(Long id, PatchMenuListRequest patchMenuListRequest) {
+        MenuList menuList = menuListRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("MenuList not found"));
+
+        if (patchMenuListRequest.getTitle() != null){
+            menuList.setTitle(patchMenuListRequest.getTitle());
+        }
+        if (patchMenuListRequest.getImgUrl() != null){
+            menuList.setImgUrl(patchMenuListRequest.getImgUrl());
+        }
+
+        return menuListRepository.save(menuList);
     }
 
     // 메뉴판 삭제

--- a/src/main/java/com/ourMenu/backend/domain/menulist/domain/MenuList.java
+++ b/src/main/java/com/ourMenu/backend/domain/menulist/domain/MenuList.java
@@ -1,10 +1,12 @@
 package com.ourMenu.backend.domain.menulist.domain;
 
 import com.ourMenu.backend.domain.menu.domain.MenuMenuList;
+import com.ourMenu.backend.domain.menu.domain.MenuStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.security.Timestamp;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,19 +26,29 @@ public class MenuList {
     @Enumerated(EnumType.STRING)
     private MenuListStatus status;
 
-    private Timestamp createdAt;
-    private Timestamp modifiedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
     private String title;
 
     @Lob
     @Column(name = "image")
-    private String ImgUrl;
+    private String imgUrl;
 
 
     @OneToMany(mappedBy = "menuList", cascade = CascadeType.ALL)
     @Builder.Default
     private List<MenuMenuList> menuMenuLists = new ArrayList<>();
 
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.status = (this.status == null) ? MenuListStatus.CREATED : this.status;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.modifiedAt = LocalDateTime.now();
+    }
 
     //** 연관관계 메서드 **//
     public void addMenuMenuList(MenuMenuList menuMenuList){

--- a/src/main/java/com/ourMenu/backend/domain/menulist/dto/request/PatchMenuListRequest.java
+++ b/src/main/java/com/ourMenu/backend/domain/menulist/dto/request/PatchMenuListRequest.java
@@ -1,0 +1,9 @@
+package com.ourMenu.backend.domain.menulist.dto.request;
+
+import lombok.Data;
+
+@Data
+public class PatchMenuListRequest {
+    private String title;
+    private String imgUrl;
+}

--- a/src/main/java/com/ourMenu/backend/domain/menulist/dto/request/PostMenuListRequest.java
+++ b/src/main/java/com/ourMenu/backend/domain/menulist/dto/request/PostMenuListRequest.java
@@ -1,0 +1,11 @@
+package com.ourMenu.backend.domain.menulist.dto.request;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class PostMenuListRequest {
+    private String imgUrl;
+    private String title;
+}

--- a/src/main/java/com/ourMenu/backend/domain/menulist/dto/response/MenuListDto.java
+++ b/src/main/java/com/ourMenu/backend/domain/menulist/dto/response/MenuListDto.java
@@ -1,6 +1,7 @@
 package com.ourMenu.backend.domain.menulist.dto.response;
 
 import com.ourMenu.backend.domain.menu.domain.MenuMenuList;
+import com.ourMenu.backend.domain.menu.dto.response.MenuDto;
 import com.ourMenu.backend.domain.menulist.domain.MenuListStatus;
 import lombok.Builder;
 import lombok.Data;
@@ -25,6 +26,6 @@ public class MenuListDto {
 
     private String imgUrl;
 
-    private List<MenuMenuList> menuMenuLists = new ArrayList<>();
+    private List<MenuDto> menus;
 
 }

--- a/src/main/java/com/ourMenu/backend/domain/menulist/dto/response/MenuListDto.java
+++ b/src/main/java/com/ourMenu/backend/domain/menulist/dto/response/MenuListDto.java
@@ -1,0 +1,30 @@
+package com.ourMenu.backend.domain.menulist.dto.response;
+
+import com.ourMenu.backend.domain.menu.domain.MenuMenuList;
+import com.ourMenu.backend.domain.menulist.domain.MenuListStatus;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@Builder
+public class MenuListDto {
+
+    private Long id;
+
+    private MenuListStatus status;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime modifiedAt;
+
+    private String title;
+
+    private String imgUrl;
+
+    private List<MenuMenuList> menuMenuLists = new ArrayList<>();
+
+}

--- a/src/main/java/com/ourMenu/backend/domain/menulist/dto/response/PostMenuListResponse.java
+++ b/src/main/java/com/ourMenu/backend/domain/menulist/dto/response/PostMenuListResponse.java
@@ -1,0 +1,10 @@
+package com.ourMenu.backend.domain.menulist.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class PostMenuListResponse {
+    private Long id;
+}


### PR DESCRIPTION
### ✏️ 작업 개요
메뉴판 API 구현 및 메뉴 리팩토링

### ⛳ 작업 분류
- [x] 작업1 메뉴판 DTO 클래스 생성
- [x] 작업2 메뉴판 생성일, 수정일 구현
- [x] 작업3 메뉴판 API 구현
- [x] 작업4 메뉴 리팩토링

### 🔨 작업 상세 내용
  1. 각각의 HTTP 메서드에 해당하는 메뉴판 DTO 클래스를 생성하였습니다. 메뉴판 전체 정보를 건내주는 경우 MenuListDto를 사용하였습니다.
  2. 메뉴판의 생성일, 수정일 구현하였습니다.
  3. 메뉴판 API(메뉴판 등록, 전체 조회 및 단건 조회, 메뉴판 수정, 삭제, 메뉴판에 메뉴 추가 및 삭제)를 구현하였습니다.
  4. 메뉴판에 메뉴를 추가하는 경우 무한으로 데이터를 땡겨오는 현상이 발생하여 DTO 클래스를 구체화하여 해결하였습니다.(검토 필요)
  5. 메뉴에서의 Response 생성 시 중복되는 코드를 MenuDto로 추출하였습니다.


### 💡 생각해볼 문제
- 생각해볼 내용을 적습니다
- 로컬에서 Postman을 통해 테스트해봤을 때 정상적으로 작동하는 것은 확인했으나, 이와 같은 방식으로 코드를 작성해도 되는지 잘 모르겠습니다..
- 메뉴  혹은 메뉴판에서 DTO 클래스를 생성하여 필요없어진 클래스들은 삭제해야 할 것 같습니다.
- 메뉴와 메뉴판의 Status가 같은데 공통으로 관리해도 될 것 같습니다.
