### PR TITLE
Feat/search

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -46,6 +46,7 @@ jobs:
           SPRING_DATASOURCE_URL: jdbc:mysql://127.0.0.1:3306/testdb
           SPRING_DATASOURCE_USERNAME: root
           SPRING_DATASOURCE_PASSWORD: testdb
+          SPRING_DATA_MONGODB_URL: ${{ secrets.MONGODB_URL }}
         run: ./gradlew build --stacktrace
 
       # dockerfile을 통해 이미지를 빌드하고, 이를 docker repo로 push

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,6 +51,7 @@ jobs:
           SPRING_DATASOURCE_URL: jdbc:mysql://127.0.0.1:3306/testdb
           SPRING_DATASOURCE_USERNAME: root
           SPRING_DATASOURCE_PASSWORD: testdb
+          SPRING_DATA_MONGODB_URL: ${{ secrets.MONGODB_URL }}
         run: ./gradlew build --stacktrace
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 	//validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	//mongodb
+	implementation ('org.springframework.boot:spring-boot-starter-data-mongodb')
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME}
       SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD}
       SWAGGER_SERVER_URL: https://bluesparrow.shop
+      SPRING_DATA_MONGODB_URL: ${{ MONGODB_URL }}
     depends_on:
       - database
     networks:

--- a/src/main/java/com/ourMenu/backend/domain/store/api/StoreController.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/api/StoreController.java
@@ -1,5 +1,6 @@
 package com.ourMenu.backend.domain.store.api;
 
+import com.ourMenu.backend.domain.store.api.response.GetStoresSearch;
 import com.ourMenu.backend.domain.store.application.StoreService;
 import com.ourMenu.backend.domain.store.domain.Store;
 import com.ourMenu.backend.domain.store.dao.StoreRepository;
@@ -14,15 +15,15 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("search")
+@RequestMapping("stores")
 @RequiredArgsConstructor
 public class StoreController {
 
     private final StoreService storeService;
 
-    @GetMapping
-    public ApiResponse<List<Store>>search(@RequestParam("string")String name){
+    @GetMapping("/search")
+    public ApiResponse<List<GetStoresSearch>>search(@RequestParam String name){
         List<Store> storeList = storeService.searchStore(name);
-        return ApiUtils.success(storeList);
+        return ApiUtils.success(storeList.stream().map(GetStoresSearch::toDto).toList());
     }
 }

--- a/src/main/java/com/ourMenu/backend/domain/store/api/StoreController.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/api/StoreController.java
@@ -1,0 +1,28 @@
+package com.ourMenu.backend.domain.store.api;
+
+import com.ourMenu.backend.domain.store.application.StoreService;
+import com.ourMenu.backend.domain.store.domain.Store;
+import com.ourMenu.backend.domain.store.dao.StoreRepository;
+import com.ourMenu.backend.global.common.ApiResponse;
+import com.ourMenu.backend.global.util.ApiUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("search")
+@RequiredArgsConstructor
+public class StoreController {
+
+    private final StoreService storeService;
+
+    @GetMapping
+    public ApiResponse<List<Store>>search(@RequestParam("string")String name){
+        List<Store> storeList = storeService.searchStore(name);
+        return ApiUtils.success(storeList);
+    }
+}

--- a/src/main/java/com/ourMenu/backend/domain/store/api/StoreController.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/api/StoreController.java
@@ -4,7 +4,9 @@ import com.ourMenu.backend.domain.store.api.response.GetStoresSearch;
 import com.ourMenu.backend.domain.store.application.StoreService;
 import com.ourMenu.backend.domain.store.domain.Store;
 import com.ourMenu.backend.domain.store.dao.StoreRepository;
+import com.ourMenu.backend.domain.store.exception.SearchResultNotFoundException;
 import com.ourMenu.backend.global.common.ApiResponse;
+import com.ourMenu.backend.global.exception.ErrorResponse;
 import com.ourMenu.backend.global.util.ApiUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+
+import static com.ourMenu.backend.global.exception.ErrorCode.SEARCH_RESULT_NOT_FOUND;
 
 @RestController
 @RequestMapping("stores")
@@ -24,6 +28,10 @@ public class StoreController {
     @GetMapping("/search")
     public ApiResponse<List<GetStoresSearch>>search(@RequestParam String name){
         List<Store> storeList = storeService.searchStore(name);
+        if(storeList.size()==0){
+           throw new SearchResultNotFoundException();
+
+        }
         return ApiUtils.success(storeList.stream().map(GetStoresSearch::toDto).toList());
     }
 }

--- a/src/main/java/com/ourMenu/backend/domain/store/api/response/GetMenuSearch.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/api/response/GetMenuSearch.java
@@ -1,0 +1,20 @@
+package com.ourMenu.backend.domain.store.api.response;
+
+import com.ourMenu.backend.domain.store.domain.Menu;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class GetMenuSearch {
+
+    private String name;
+    private String price;
+
+    public static GetMenuSearch toDto(Menu menu){
+        return GetMenuSearch.builder()
+                .name(menu.getName())
+                .price(menu.getPrice())
+                .build();
+    }
+}

--- a/src/main/java/com/ourMenu/backend/domain/store/api/response/GetStoresSearch.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/api/response/GetStoresSearch.java
@@ -1,0 +1,43 @@
+package com.ourMenu.backend.domain.store.api.response;
+
+import com.ourMenu.backend.domain.store.domain.Menu;
+import com.ourMenu.backend.domain.store.domain.Store;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+@Getter
+public class GetStoresSearch {
+
+    private String name;
+    private String address;
+    private String type;
+    private List<String> images;
+    private List<GetMenuSearch> menus;
+    private String time;
+
+    public static GetStoresSearch toDto(Store store){
+        List<GetMenuSearch> menuList;
+        if (store.getMenu() != null) {
+            menuList = store.getMenu().stream()
+                    .map(GetMenuSearch::toDto)
+                    .toList();
+        }
+        else{
+            menuList= Collections.emptyList();
+        }
+        return GetStoresSearch.builder()
+                .name(store.getName())
+                .address(store.getAddress())
+                .type(store.getType())
+                .images(store.getImages())
+                .menus(menuList)
+                .time(store.getTime())
+                .build();
+    }
+}

--- a/src/main/java/com/ourMenu/backend/domain/store/application/StoreService.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/application/StoreService.java
@@ -1,0 +1,30 @@
+package com.ourMenu.backend.domain.store.application;
+
+import com.ourMenu.backend.domain.store.dao.StoreRepository;
+import com.ourMenu.backend.domain.store.domain.Store;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StoreService {
+
+    public final StoreRepository storeRepository;
+
+    /**
+     * 제목에 name을 포함 하는 음식점을 반환한다.(5개)
+     * @param name
+     * @return 음식점 갯수
+     */
+    public List<Store> searchStore(String name){
+        Pageable pageable= PageRequest.of(0,5);
+        //return storeRepository.findByNameContaining(name);
+        Page<Store> page=storeRepository.findByNameContaining(name,pageable);
+        return page.getContent();
+    }
+}

--- a/src/main/java/com/ourMenu/backend/domain/store/config/MongoConfig.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/config/MongoConfig.java
@@ -1,0 +1,30 @@
+package com.ourMenu.backend.domain.store.config;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+
+@Configuration
+@EnableMongoRepositories(basePackages = "com.ourMenu")
+public class MongoConfig extends AbstractMongoClientConfiguration{
+
+    @Value("${spring.data.mongodb.url}")
+    private String url;
+    @Override
+    protected String getDatabaseName() {
+        return "ourmenu"; // 데이터베이스 이름 설정
+    }
+
+    @Bean
+    @Override
+    public MongoClient mongoClient() {
+        return MongoClients.create(url); // MongoDB 연결 URI 설정
+    }
+
+}

--- a/src/main/java/com/ourMenu/backend/domain/store/dao/StoreRepository.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/dao/StoreRepository.java
@@ -1,0 +1,19 @@
+package com.ourMenu.backend.domain.store.dao;
+
+import com.ourMenu.backend.domain.store.domain.Store;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface StoreRepository extends MongoRepository<Store, String> {
+    Optional<Store> findByName(String name);
+
+    List<Store> findByNameContaining(String name);
+    Page<Store> findByNameContaining(String name, Pageable pageable);
+}

--- a/src/main/java/com/ourMenu/backend/domain/store/domain/Menu.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/domain/Menu.java
@@ -1,0 +1,15 @@
+package com.ourMenu.backend.domain.store.domain;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+
+public class Menu {
+
+    private String name;
+    private String price;
+}

--- a/src/main/java/com/ourMenu/backend/domain/store/domain/Store.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/domain/Store.java
@@ -1,0 +1,22 @@
+package com.ourMenu.backend.domain.store.domain;
+
+import jakarta.persistence.Id;
+import lombok.*;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document(collection = "store") // 실제 몽고 DB 컬렉션 이름
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Store {
+    @Id
+    private String id;
+    private String name;
+    private String address;
+    private String type;
+    private List<String> images;
+    private List<Menu> menu;
+    private String time;
+}

--- a/src/main/java/com/ourMenu/backend/domain/store/exception/SearchResultNotFoundException.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/exception/SearchResultNotFoundException.java
@@ -1,0 +1,12 @@
+package com.ourMenu.backend.domain.store.exception;
+
+import com.ourMenu.backend.global.exception.CustomException;
+import com.ourMenu.backend.global.exception.ErrorCode;
+
+public class SearchResultNotFoundException extends CustomException {
+
+    public SearchResultNotFoundException(){
+        super(ErrorCode.SEARCH_RESULT_NOT_FOUND);
+    }
+
+}

--- a/src/main/java/com/ourMenu/backend/global/exception/CustomException.java
+++ b/src/main/java/com/ourMenu/backend/global/exception/CustomException.java
@@ -1,0 +1,20 @@
+package com.ourMenu.backend.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/com/ourMenu/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/ourMenu/backend/global/exception/ErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"G500","서버 내부에서 에러가 발생하였습니다"),
+    MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "G400", "요청 파라미터가 누락되었습니다"),
 
     //search
     SEARCH_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND,"S404","검색 결과가 없습니다")

--- a/src/main/java/com/ourMenu/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/ourMenu/backend/global/exception/ErrorCode.java
@@ -8,7 +8,11 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
 
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"G500","서버 내부에서 에러가 발생하였습니다");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"G500","서버 내부에서 에러가 발생하였습니다"),
+
+    //search
+    SEARCH_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND,"S404","검색 결과가 없습니다")
+    ;
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/ourMenu/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ourMenu/backend/global/exception/GlobalExceptionHandler.java
@@ -21,6 +21,10 @@ public class GlobalExceptionHandler {
     private ResponseEntity<?> handleMethodArgumentNotValidException(MethodArgumentNotValidException e){
         return handleException(e,ErrorCode.INTERNAL_SERVER_ERROR, e.getBindingResult().getFieldError().getDefaultMessage());
     }
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<?> handleBusinessException(CustomException e) {
+        return handleException(e, e.getErrorCode(), e.getMessage());
+    }
 
     private ResponseEntity<?> handleException(Exception e, ErrorCode errorCode, String message) {
         return ApiUtils.error(ErrorResponse.of(errorCode, message));

--- a/src/main/java/com/ourMenu/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ourMenu/backend/global/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -20,6 +21,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     private ResponseEntity<?> handleMethodArgumentNotValidException(MethodArgumentNotValidException e){
         return handleException(e,ErrorCode.INTERNAL_SERVER_ERROR, e.getBindingResult().getFieldError().getDefaultMessage());
+    }
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    private ResponseEntity<?> handleMissingServletRequestParameterException(MissingServletRequestParameterException e){
+        return handleException(e,ErrorCode.MISSING_PARAMETER,ErrorCode.MISSING_PARAMETER.getMessage());
     }
     @ExceptionHandler(CustomException.class)
     protected ResponseEntity<?> handleBusinessException(CustomException e) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,10 @@ spring:
   swagger:
     #server-url: http://localhost:8080
     #server-url: https://bluesparrow.shop
+  data:
+    mongodb:
+      url: ${MONGO_URL}
+      #uri: ${MONGO_URL}
   logging:
     level:
       org.hibernate.SQL: debug


### PR DESCRIPTION
### ✏️ 작업 개요
음식점 검색 API 추가

### ⛳ 작업 분류
- [x] mongodb 추가
- [x] 음식점 검색API 추가
- [x] exception 로직 추가
- [ ] 테스트 코드 작성

### 🔨 작업 상세 내용
  1. 음식점 검색 api를 추가했습니다
  2. 음식점 데이터를 mongdb에서 관리합니다
  3. 최대 5개의 음식점을 검색합니다.
  4. 제목기준으로 검색를 진행합니다

### 💡 생각해볼 문제
- 현재 사전 음식점을 통해 사용자가 메뉴판을 만들면 유저에게 메뉴가 종속되게 됩니다. erd도 사전 음식점과 유저를 분리되어 있습니다.
- 사전 음식점은 변경이 되지 않는 데이터, 조인연산이 필요 없는 데이터라는 측면에서 nosql에 적절하다고 생각했습니다.
- mongodb atlas(원격 db)에 음식점 데이터(광진구)를 저장했습니다.
- 환경변수는 account에 명세했습니다
- #18 
