### PR TITLE
Feat/develop

### DIFF
--- a/src/main/java/com/ourMenu/backend/domain/menu/api/MenuApiController.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/api/MenuApiController.java
@@ -1,15 +1,14 @@
 package com.ourMenu.backend.domain.menu.api;
 
 import com.ourMenu.backend.domain.menu.application.MenuService;
-import com.ourMenu.backend.domain.menu.dao.MenuRepository;
 import com.ourMenu.backend.domain.menu.domain.*;
-import com.ourMenu.backend.domain.menu.dto.request.PatchMenuRequest;
 import com.ourMenu.backend.domain.menu.dto.request.PostMenuRequest;
 import com.ourMenu.backend.domain.menu.dto.request.PostPhotoRequest;
+import com.ourMenu.backend.domain.menu.dto.response.PlaceMenuDTO;
+import com.ourMenu.backend.domain.menu.dto.response.PlaceMenuFolderDTO;
 import com.ourMenu.backend.domain.menu.dto.response.PostMenuResponse;
-import com.ourMenu.backend.domain.menu.dto.response.MenuDto;
+import com.ourMenu.backend.domain.menu.dto.response.TagDTO;
 import com.ourMenu.backend.domain.menulist.application.MenuListService;
-import com.ourMenu.backend.domain.menulist.dao.MenuListRepository;
 import com.ourMenu.backend.domain.menulist.domain.MenuList;
 import com.ourMenu.backend.global.common.ApiResponse;
 import com.ourMenu.backend.global.util.ApiUtils;
@@ -21,7 +20,6 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @RestController
 @RequestMapping("/menu")
@@ -116,6 +114,32 @@ public class MenuApiController {
         }
 
         return ApiUtils.success("OK");
+    }
+
+    @GetMapping("/{placeId}")
+    public ApiResponse<List<PlaceMenuDTO>> findMenuByPlace(@PathVariable Long placeId) {
+        List<Menu> menuList = menuService.findMenuByPlace(placeId);
+        List<PlaceMenuDTO> response = menuList.stream().map(menu ->
+                PlaceMenuDTO.builder()
+                        .menuId(menu.getId())
+                        .menuTitle(menu.getTitle())
+                        .price(menu.getPrice())
+                        .icon(menu.getIcon())
+                        .tags(menu.getTags().stream().map(tag ->
+                                TagDTO.builder()
+                                        .tagTitle(tag.getTag().getName())
+                                        .isCustom(tag.getTag().getIsCustom())
+                                        .build())
+                                .collect(Collectors.toList())
+                        )
+                        .images(menu.getImages())
+                        .menuFolder(PlaceMenuFolderDTO.builder()
+                                .menuFolderTitle(menu.getMenuList().getTitle())
+                                .icon(menu.getMenuList().getIconType())
+                                .build())
+                        .build())
+                .collect(Collectors.toList());
+        return ApiUtils.success(response);
     }
 
     /*

--- a/src/main/java/com/ourMenu/backend/domain/menu/application/MenuService.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/application/MenuService.java
@@ -4,11 +4,13 @@ import com.ourMenu.backend.domain.menu.domain.MenuStatus;
 import com.ourMenu.backend.domain.menu.dao.MenuRepository;
 import com.ourMenu.backend.domain.menu.domain.Menu;
 import com.ourMenu.backend.domain.menu.dto.request.PatchMenuRequest;
+import com.ourMenu.backend.domain.menu.dto.response.PlaceMenuDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Service
@@ -34,6 +36,11 @@ public class MenuService {
     @Transactional
     public Menu createMenu(Menu menu) {
         return menuRepository.save(menu);
+    }
+
+    @Transactional
+    public List<Menu> findMenuByPlace(Long placeId){
+        return menuRepository.findMenuByPlaceId(placeId, Arrays.asList(MenuStatus.CREATED, MenuStatus.UPDATED));
     }
 
     // 메뉴 업데이트

--- a/src/main/java/com/ourMenu/backend/domain/menu/dao/MenuRepository.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/dao/MenuRepository.java
@@ -1,7 +1,15 @@
 package com.ourMenu.backend.domain.menu.dao;
 
 import com.ourMenu.backend.domain.menu.domain.Menu;
+import com.ourMenu.backend.domain.menu.domain.MenuStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface MenuRepository extends JpaRepository<Menu, Long> {
+
+    @Query("SELECT m FROM Menu m WHERE m.place.id = :placeId AND m.status IN :status")
+    List<Menu> findMenuByPlaceId(@Param("placeId") Long placeId, @Param("status")List<MenuStatus> statuses);
 }

--- a/src/main/java/com/ourMenu/backend/domain/menu/dto/response/PlaceMenuDTO.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/dto/response/PlaceMenuDTO.java
@@ -1,0 +1,21 @@
+package com.ourMenu.backend.domain.menu.dto.response;
+
+import com.ourMenu.backend.domain.menu.domain.MenuImage;
+import com.ourMenu.backend.domain.menu.domain.Tag;
+import com.ourMenu.backend.domain.menulist.domain.MenuList;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class PlaceMenuDTO {
+    private Long menuId;
+    private String menuTitle;
+    private int price;
+    private String icon;
+    private List<TagDTO> tags;
+    private List<MenuImage> images;
+    private PlaceMenuFolderDTO menuFolder;
+}

--- a/src/main/java/com/ourMenu/backend/domain/menu/dto/response/PlaceMenuFolderDTO.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/dto/response/PlaceMenuFolderDTO.java
@@ -1,0 +1,11 @@
+package com.ourMenu.backend.domain.menu.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class PlaceMenuFolderDTO {
+    private String menuFolderTitle;
+    private String icon;
+}

--- a/src/main/java/com/ourMenu/backend/domain/menu/dto/response/TagDTO.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/dto/response/TagDTO.java
@@ -1,0 +1,11 @@
+package com.ourMenu.backend.domain.menu.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class TagDTO {
+    private String tagTitle;
+    private boolean isCustom;
+}

--- a/src/main/java/com/ourMenu/backend/domain/menulist/application/MenuListService.java
+++ b/src/main/java/com/ourMenu/backend/domain/menulist/application/MenuListService.java
@@ -12,8 +12,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+
+import static com.ourMenu.backend.domain.menulist.domain.MenuListStatus.*;
 
 
 @Service
@@ -40,21 +44,20 @@ public class MenuListService {
     // 메뉴판 조회 //
     @Transactional
     public MenuList getMenuListByName(String title) {
-        return menuListRepository.findByTitle(title)
-                .orElseThrow(() -> new RuntimeException("해당하는 메뉴판이 없습니다."));
+        return menuListRepository.findMenuListByTitle(title, Arrays.asList(CREATED, UPDATED));
     }
 
     //메뉴판 전체 조회
     @Transactional
     public List<MenuList> getAllMenuList(){
-        return menuListRepository.findAll();
+        return menuListRepository.findAllMenuList(Arrays.asList(CREATED, UPDATED));
     }
 
     //메뉴판 업데이트
     @Transactional
     public MenuList updateMenuList(Long id, MenuListRequestDTO request) {
         MenuList menuList = menuListRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("MenuList not found"));
+                .orElseThrow(() -> new RuntimeException("해당하는 메뉴판이 없습니다."));
 
         MenuList.MenuListBuilder updateMenuListBuilder = menuList.toBuilder();
 
@@ -79,7 +82,7 @@ public class MenuListService {
     @Transactional
     public String removeMenuList(Long id){
         MenuList menuList = menuListRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("MenuList not found"));
+                .orElseThrow(() -> new RuntimeException("해당하는 메뉴판이 없습니다."));
 
         MenuList.MenuListBuilder removeMenuListBuilder = menuList.toBuilder();
 

--- a/src/main/java/com/ourMenu/backend/domain/menulist/application/MenuListService.java
+++ b/src/main/java/com/ourMenu/backend/domain/menulist/application/MenuListService.java
@@ -90,6 +90,8 @@ public class MenuListService {
 
         MenuList removeMenuList = removeMenuListBuilder.build();
 
+        menuListRepository.save(removeMenuList);
+
         return "OK";
     }
 

--- a/src/main/java/com/ourMenu/backend/domain/menulist/dao/MenuListRepository.java
+++ b/src/main/java/com/ourMenu/backend/domain/menulist/dao/MenuListRepository.java
@@ -1,10 +1,20 @@
 package com.ourMenu.backend.domain.menulist.dao;
 
 import com.ourMenu.backend.domain.menulist.domain.MenuList;
+import com.ourMenu.backend.domain.menulist.domain.MenuListStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MenuListRepository extends JpaRepository<MenuList, Long> {
     Optional<MenuList> findByTitle(String title);
+
+    @Query("SELECT m FROM MenuList m WHERE m.status IN :status")
+    List<MenuList> findAllMenuList(@Param("status")List<MenuListStatus> status);
+
+    @Query("SELECT m FROM MenuList m WHERE m.title = :title AND m.status IN (:status)")
+    MenuList findMenuListByTitle(@Param("title") String title, @Param("status")List<MenuListStatus> status);
 }


### PR DESCRIPTION
### ✏️ 작업 개요
식당ID로 메뉴 조회(feat/develop 브랜치 PR)

### ⛳ 작업 분류
- [x] 작업1 메뉴판 삭제 API 수정
- [x] 작업2 식당ID로 메뉴 조회 구현

### 🔨 작업 상세 내용
  1. 메뉴판 삭제를 통한 Status의 "DELETED" 저장이 DB에 반영되지 않던 것을 수정하였습니다.
  2. 식당의 ID를 통해 해당 식당에 존재하는 메뉴들("DELETED" 제외) 조회 API를 구현하였습니다.(/menu/{placeId})

### 💡 생각해볼 문제
- 전체적으로 궁금한 것인데, 위와 같은 placeId 외에도 메뉴판의 변경 및 삭제와 같은 기능에서도 id가 필요한데 이는 프론트에서 어떻게 입력받는지 알고싶습니다.
