### PR TITLE
Fix/search

### DIFF
--- a/src/main/java/com/ourMenu/backend/domain/store/api/StoreController.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/api/StoreController.java
@@ -19,15 +19,14 @@ import java.util.List;
 import static com.ourMenu.backend.global.exception.ErrorCode.SEARCH_RESULT_NOT_FOUND;
 
 @RestController
-@RequestMapping("stores")
 @RequiredArgsConstructor
 public class StoreController {
 
     private final StoreService storeService;
 
-    @GetMapping("/search")
-    public ApiResponse<List<GetStoresSearch>>search(@RequestParam String name){
-        List<Store> storeList = storeService.searchStore(name);
+    @GetMapping("/place/info")
+    public ApiResponse<List<GetStoresSearch>>search(@RequestParam String title){
+        List<Store> storeList = storeService.searchStore(title);
         if(storeList.size()==0){
            throw new SearchResultNotFoundException();
 

--- a/src/main/java/com/ourMenu/backend/global/config/WebConfig.java
+++ b/src/main/java/com/ourMenu/backend/global/config/WebConfig.java
@@ -30,7 +30,8 @@ public class WebConfig implements WebMvcConfigurer {
                         "/account/reissueToken",
                         "/swagger-ui/**",
                         "/swagger-resources/**",
-                        "/v3/api-docs/**");
+                        "/v3/api-docs/**",
+                        "/dummy/**");
     }
 
     @Override

--- a/src/main/java/com/ourMenu/backend/global/config/WebConfig.java
+++ b/src/main/java/com/ourMenu/backend/global/config/WebConfig.java
@@ -31,7 +31,8 @@ public class WebConfig implements WebMvcConfigurer {
                         "/swagger-ui/**",
                         "/swagger-resources/**",
                         "/v3/api-docs/**",
-                        "/dummy/**");
+                        "/dummy/**",
+                        "/place/info");
     }
 
     @Override


### PR DESCRIPTION
### ✏️ 작업 개요
검색 API endpoint 변경

### ⛳ 작업 분류
- [x] /place/info 변경
- [x] webconfig 변경


### 🔨 작업 상세 내용
  1. 기존에 stores/search를 /place/info로 변경(동일한 api)
  2. dummy api 토근 없이 허용
  3. stores/search api 토근 없이 허용(프론트 작업시 비효율성 방지)

### 💡 생각해볼 문제
- 생각해볼 내용을 적습니다
