### PR TITLE
Feat/search track

### DIFF
--- a/src/main/java/com/ourMenu/backend/domain/store/api/StoreController.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/api/StoreController.java
@@ -1,8 +1,10 @@
 package com.ourMenu.backend.domain.store.api;
 
+import com.ourMenu.backend.domain.store.api.response.GetSearchHistory;
 import com.ourMenu.backend.domain.store.api.response.GetStoresSearch;
 import com.ourMenu.backend.domain.store.application.StoreService;
 import com.ourMenu.backend.domain.store.domain.Store;
+import com.ourMenu.backend.domain.store.domain.UserStore;
 import com.ourMenu.backend.domain.store.exception.SearchResultNotFoundException;
 import com.ourMenu.backend.global.argument_resolver.UserId;
 import com.ourMenu.backend.global.common.ApiResponse;
@@ -37,5 +39,13 @@ public class StoreController {
                                                  @UserId Long userId) {
         Store findStore = storeService.findOneByUser(id, userId);
         return ApiUtils.success(GetStoresSearch.toDto(findStore));
+    }
+
+    @GetMapping("/place/search-history")
+    public ApiResponse<List<GetSearchHistory>> getSearchHistory(@Parameter(hidden = true)
+                                                             @UserId Long userId) {
+        List<UserStore> storeList=storeService.findHistory(userId);
+
+        return ApiUtils.success(storeList.stream().map(GetSearchHistory::toDto).toList());
     }
 }

--- a/src/main/java/com/ourMenu/backend/domain/store/api/StoreController.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/api/StoreController.java
@@ -33,4 +33,9 @@ public class StoreController {
         }
         return ApiUtils.success(storeList.stream().map(GetStoresSearch::toDto).toList());
     }
+    @GetMapping("/place/{id}")
+    public ApiResponse<GetStoresSearch>findById(@RequestParam("id")String id){
+        Store findStore = storeService.findById(id);
+        return ApiUtils.success(GetStoresSearch.toDto(findStore));
+    }
 }

--- a/src/main/java/com/ourMenu/backend/domain/store/api/StoreController.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/api/StoreController.java
@@ -3,20 +3,17 @@ package com.ourMenu.backend.domain.store.api;
 import com.ourMenu.backend.domain.store.api.response.GetStoresSearch;
 import com.ourMenu.backend.domain.store.application.StoreService;
 import com.ourMenu.backend.domain.store.domain.Store;
-import com.ourMenu.backend.domain.store.dao.StoreRepository;
 import com.ourMenu.backend.domain.store.exception.SearchResultNotFoundException;
+import com.ourMenu.backend.global.argument_resolver.UserId;
 import com.ourMenu.backend.global.common.ApiResponse;
-import com.ourMenu.backend.global.exception.ErrorResponse;
 import com.ourMenu.backend.global.util.ApiUtils;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-
-import static com.ourMenu.backend.global.exception.ErrorCode.SEARCH_RESULT_NOT_FOUND;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,17 +22,18 @@ public class StoreController {
     private final StoreService storeService;
 
     @GetMapping("/place/info")
-    public ApiResponse<List<GetStoresSearch>>search(@RequestParam String title){
+    public ApiResponse<List<GetStoresSearch>> search(@RequestParam String title) {
         List<Store> storeList = storeService.searchStore(title);
-        if(storeList.size()==0){
-           throw new SearchResultNotFoundException();
+        if (storeList.size() == 0) {
+            throw new SearchResultNotFoundException();
 
         }
         return ApiUtils.success(storeList.stream().map(GetStoresSearch::toDto).toList());
     }
+
     @GetMapping("/place/{id}")
-    public ApiResponse<GetStoresSearch>findById(@RequestParam("id")String id){
-        Store findStore = storeService.findById(id);
+    public ApiResponse<GetStoresSearch> findById(@RequestParam("id") String id, @Parameter(hidden = true) @UserId Long userId) {
+        Store findStore = storeService.findOneByUser(id, userId);
         return ApiUtils.success(GetStoresSearch.toDto(findStore));
     }
 }

--- a/src/main/java/com/ourMenu/backend/domain/store/api/StoreController.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/api/StoreController.java
@@ -32,7 +32,9 @@ public class StoreController {
     }
 
     @GetMapping("/place/{id}")
-    public ApiResponse<GetStoresSearch> findById(@RequestParam("id") String id, @Parameter(hidden = true) @UserId Long userId) {
+    public ApiResponse<GetStoresSearch> findById(@RequestParam("id") String id,
+                                                 @Parameter(hidden = true)
+                                                 @UserId Long userId) {
         Store findStore = storeService.findOneByUser(id, userId);
         return ApiUtils.success(GetStoresSearch.toDto(findStore));
     }

--- a/src/main/java/com/ourMenu/backend/domain/store/api/StoreController.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/api/StoreController.java
@@ -12,6 +12,7 @@ import com.ourMenu.backend.global.util.ApiUtils;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,11 +20,12 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/place")
 public class StoreController {
 
     private final StoreService storeService;
 
-    @GetMapping("/place/info")
+    @GetMapping("/info")
     public ApiResponse<List<GetStoresSearch>> search(@RequestParam String title) {
         List<Store> storeList = storeService.searchStore(title);
         if (storeList.size() == 0) {
@@ -33,7 +35,7 @@ public class StoreController {
         return ApiUtils.success(storeList.stream().map(GetStoresSearch::toDto).toList());
     }
 
-    @GetMapping("/place/{id}")
+    @GetMapping("/{id}")
     public ApiResponse<GetStoresSearch> findById(@RequestParam("id") String id,
                                                  @Parameter(hidden = true)
                                                  @UserId Long userId) {
@@ -41,7 +43,7 @@ public class StoreController {
         return ApiUtils.success(GetStoresSearch.toDto(findStore));
     }
 
-    @GetMapping("/place/search-history")
+    @GetMapping("/search-history")
     public ApiResponse<List<GetSearchHistory>> getSearchHistory(@Parameter(hidden = true)
                                                              @UserId Long userId) {
         List<UserStore> storeList=storeService.findHistory(userId);

--- a/src/main/java/com/ourMenu/backend/domain/store/api/response/GetSearchHistory.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/api/response/GetSearchHistory.java
@@ -1,0 +1,29 @@
+package com.ourMenu.backend.domain.store.api.response;
+
+import com.ourMenu.backend.domain.store.domain.UserStore;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Builder
+@Getter
+public class GetSearchHistory {
+
+    private String storeName;
+
+    private String address;
+
+    private LocalDateTime modifiedAt;
+
+    public static GetSearchHistory toDto(UserStore userStore){
+        return GetSearchHistory.builder()
+                .storeName(userStore.getStoreName())
+                .address(userStore.getAddress())
+                .modifiedAt(userStore.getModifiedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/ourMenu/backend/domain/store/api/response/GetStoresSearch.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/api/response/GetStoresSearch.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 @Getter
 public class GetStoresSearch {
 
+    private String id;
     private String name;
     private String address;
     private String type;
@@ -34,6 +35,7 @@ public class GetStoresSearch {
             menuList= Collections.emptyList();
         }
         return GetStoresSearch.builder()
+                .id(store.getId())
                 .name(store.getName())
                 .address(store.getAddress())
                 .type(store.getType())

--- a/src/main/java/com/ourMenu/backend/domain/store/application/StoreService.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/application/StoreService.java
@@ -4,6 +4,7 @@ import com.ourMenu.backend.domain.store.dao.StoreRepository;
 import com.ourMenu.backend.domain.store.dao.UserStoreRepository;
 import com.ourMenu.backend.domain.store.domain.Store;
 import com.ourMenu.backend.domain.store.domain.UserStore;
+import com.ourMenu.backend.domain.store.exception.SearchResultNotFoundException;
 import com.ourMenu.backend.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -46,7 +47,7 @@ public class StoreService {
     public Store findOneByUser(String id, Long userId) {
         Optional<Store> optionalStore = storeRepository.findById(id);
         if (optionalStore.isEmpty())
-            throw new RuntimeException("찾을 수 없는 가게 입니다.");
+            throw new SearchResultNotFoundException();
         updateUserStore(optionalStore.get(),userId);
         return optionalStore.get();
     }

--- a/src/main/java/com/ourMenu/backend/domain/store/application/StoreService.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/application/StoreService.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -18,13 +19,21 @@ public class StoreService {
 
     /**
      * 제목에 name을 포함 하는 음식점을 반환한다.(5개)
+     *
      * @param name
      * @return 음식점 갯수
      */
-    public List<Store> searchStore(String name){
-        Pageable pageable= PageRequest.of(0,15);
+    public List<Store> searchStore(String name) {
+        Pageable pageable = PageRequest.of(0, 15);
         //return storeRepository.findByNameContaining(name);
-        Page<Store> page=storeRepository.findByNameContaining(name,pageable);
+        Page<Store> page = storeRepository.findByNameContaining(name, pageable);
         return page.getContent();
+    }
+
+    public Store findById(String id) {
+        Optional<Store> optionalStore = storeRepository.findById(id);
+        if(optionalStore.isEmpty())
+            throw new RuntimeException("asdf");
+        return  optionalStore.get();
     }
 }

--- a/src/main/java/com/ourMenu/backend/domain/store/application/StoreService.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/application/StoreService.java
@@ -67,6 +67,11 @@ public class StoreService {
         return userStoreOptional.get().updateModifiedAt();
     }
 
+    /**
+     * 검색 기록을 오름차순으로 검색한다.
+     * @param userId
+     * @return
+     */
     public List<UserStore> findHistory(Long userId) {
         return userStoreRepository.findByUserIdOrderByModifiedAtDesc(userId);
     }

--- a/src/main/java/com/ourMenu/backend/domain/store/application/StoreService.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/application/StoreService.java
@@ -66,4 +66,8 @@ public class StoreService {
         }
         return userStoreOptional.get().updateModifiedAt();
     }
+
+    public List<UserStore> findHistory(Long userId) {
+        return userStoreRepository.findByUserIdOrderByModifiedAtDesc(userId);
+    }
 }

--- a/src/main/java/com/ourMenu/backend/domain/store/application/StoreService.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/application/StoreService.java
@@ -24,7 +24,7 @@ public class StoreService {
     private final UserStoreRepository userStoreRepository;
 
     /**
-     * 제목에 name을 포함 하는 음식점을 반환한다.(5개)
+     * 제목에 name을 포함 하는 음식점을 반환한다.(15개)
      *
      * @param name
      * @return 음식점 갯수

--- a/src/main/java/com/ourMenu/backend/domain/store/application/UserStoreService.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/application/UserStoreService.java
@@ -1,0 +1,14 @@
+package com.ourMenu.backend.domain.store.application;
+
+import com.ourMenu.backend.domain.store.dao.UserStoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserStoreService {
+
+    private final UserStoreRepository userStoreRepository;
+
+
+}

--- a/src/main/java/com/ourMenu/backend/domain/store/dao/UserStoreRepository.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/dao/UserStoreRepository.java
@@ -1,0 +1,12 @@
+package com.ourMenu.backend.domain.store.dao;
+
+import com.ourMenu.backend.domain.store.domain.UserStore;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserStoreRepository extends JpaRepository<UserStore,Long> {
+    Optional<UserStore> findByUserIdAndStoreId(Long userId, String storeId);
+}

--- a/src/main/java/com/ourMenu/backend/domain/store/dao/UserStoreRepository.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/dao/UserStoreRepository.java
@@ -4,9 +4,12 @@ import com.ourMenu.backend.domain.store.domain.UserStore;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface UserStoreRepository extends JpaRepository<UserStore,Long> {
     Optional<UserStore> findByUserIdAndStoreId(Long userId, String storeId);
+
+    List<UserStore> findByUserIdOrderByModifiedAtDesc(Long userId);
 }

--- a/src/main/java/com/ourMenu/backend/domain/store/domain/UserStore.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/domain/UserStore.java
@@ -1,0 +1,45 @@
+package com.ourMenu.backend.domain.store.domain;
+
+import com.ourMenu.backend.domain.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserStore {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    private String storeId;
+
+    private String storeName;
+
+    private String address;
+
+    private LocalDateTime modifiedAt;
+
+    public static UserStore toEntity(Store store,Long userId){
+        return UserStore.builder()
+                .userId(userId)
+                .storeId(store.getId())
+                .storeName(store.getName())
+                .address(store.getAddress())
+                .modifiedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public UserStore updateModifiedAt(){
+        modifiedAt= LocalDateTime.now();
+        return this;
+    }
+}

--- a/src/main/java/com/ourMenu/backend/domain/store/domain/UserStore.java
+++ b/src/main/java/com/ourMenu/backend/domain/store/domain/UserStore.java
@@ -4,6 +4,7 @@ import com.ourMenu.backend.domain.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Getter
 public class UserStore {
 
     @Id

--- a/src/main/java/com/ourMenu/backend/global/argument_resolver/UserId.java
+++ b/src/main/java/com/ourMenu/backend/global/argument_resolver/UserId.java
@@ -8,4 +8,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface UserId {
+    boolean required() default true;
 }


### PR DESCRIPTION
### ✏️ 작업 개요
가게정보 검색시 검색 기록 API 추가

### ⛳ 작업 분류
- [x] 검색 기록 API( /store/search-history)
- [x] 가게 상세 조회 API( /store/{id}


### 🔨 작업 상세 내용
  1. userStore 도메인 추가
  2. 검색 기록 API 추가하였습니다
  3. 검색 기록을 저장하기 위해 가게 상세 조회 API를 작성했습니다
  #39 

### 💡 생각해볼 문제
- db 외래키를 전부 제거했습니다.
