### PR TITLE
feat: 메뉴판 우선순위 API

### DIFF
--- a/src/main/java/com/ourMenu/backend/domain/menulist/api/MenuListApiController.java
+++ b/src/main/java/com/ourMenu/backend/domain/menulist/api/MenuListApiController.java
@@ -53,6 +53,7 @@ public class MenuListApiController {
                 .title(menuList.getTitle())
                 .imgUrl(menuList.getImgUrl())
                 .iconType(menuList.getIconType())
+                .priority(menuList.getPriority())
                 .build();
 
         return ApiUtils.success(response);
@@ -70,6 +71,7 @@ public class MenuListApiController {
                         .menuCount((long) menuList.getMenus().size())
                         .imgUrl(menuList.getImgUrl())
                         .iconType(menuList.getIconType())
+                        .priority(menuList.getPriority())
                         .build()
         ).collect(Collectors.toList());
 
@@ -85,6 +87,7 @@ public class MenuListApiController {
                 .title(menuList.getTitle())
                 .imgUrl(menuList.getImgUrl())
                 .iconType(menuList.getIconType())
+                .priority(menuList.getPriority())
                 .build();
 
         return ApiUtils.success(response);
@@ -94,6 +97,12 @@ public class MenuListApiController {
     public ApiResponse<String> removeMenuList(@PathVariable Long id, @UserId Long userId){
         String response = menuListService.removeMenuList(id, userId);       //STATUS를 DELETED로 변환
         return ApiUtils.success(response);  //OK 반환
+    }
+
+    @PatchMapping("/priority/{id}")
+    public ApiResponse<String> changePriority(@PathVariable Long id, @RequestParam Long newPriority, @UserId Long userId){
+        String response = menuListService.setPriority(id, newPriority ,userId);
+        return ApiUtils.success(response);
     }
 
     /*

--- a/src/main/java/com/ourMenu/backend/domain/menulist/application/MenuListService.java
+++ b/src/main/java/com/ourMenu/backend/domain/menulist/application/MenuListService.java
@@ -9,7 +9,6 @@ import com.ourMenu.backend.domain.menulist.dto.request.MenuListRequestDTO;
 import com.ourMenu.backend.domain.user.application.UserService;
 import com.ourMenu.backend.domain.user.domain.User;
 import com.ourMenu.backend.domain.user.exception.UserException;
-import com.ourMenu.backend.global.common.Status;
 import com.ourMenu.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,9 +20,7 @@ import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.S3Exception;
 
-import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
@@ -174,11 +171,21 @@ public class MenuListService {
         MenuList menuList = menuListRepository.findMenuListsById(menuListId, userId, Arrays.asList(CREATED, UPDATED))
                 .orElseThrow(() -> new MenuListException("해당 메뉴판이 존재하지 않습니다."));
 
-        MenuList.MenuListBuilder removeMenuListBuilder = menuList.toBuilder();
+//        MenuList.MenuListBuilder removeMenuListBuilder = menuList.toBuilder();
+//
+//        removeMenuListBuilder.status(Status.DELETED);
+//
+//        MenuList removeMenuList = removeMenuListBuilder.build();
+//
 
-        removeMenuListBuilder.status(Status.DELETED);
+        Long currentPriority = menuList.getPriority();
+        menuList.softDelete();
+        menuListRepository.save(menuList);
 
-        MenuList removeMenuList = removeMenuListBuilder.build();
+        menuListRepository.decreasePriorityGreaterThan(currentPriority);
+
+        return "OK";
+    }
 
     @Transactional
     public String setPriority(Long id, Long newPriority, Long userId) {

--- a/src/main/java/com/ourMenu/backend/domain/menulist/dao/MenuListRepository.java
+++ b/src/main/java/com/ourMenu/backend/domain/menulist/dao/MenuListRepository.java
@@ -3,11 +3,13 @@ package com.ourMenu.backend.domain.menulist.dao;
 import com.ourMenu.backend.domain.menulist.domain.MenuList;
 import com.ourMenu.backend.domain.menulist.domain.MenuListStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 public interface MenuListRepository extends JpaRepository<MenuList, Long> {
     Optional<MenuList> findByTitle(String title);
@@ -20,5 +22,19 @@ public interface MenuListRepository extends JpaRepository<MenuList, Long> {
 
     @Query("SELECT m FROM MenuList m WHERE m.id = :menulistId AND m.user.id = :userId AND m.status IN :status")
     Optional<MenuList> findMenuListsById(@Param("menulistId") Long menulistId, @Param("userId") Long userId, @Param("status")List<MenuListStatus> status);
+
+    @Modifying
+    @Query("UPDATE MenuList m SET m.priority = m.priority - 1 WHERE m.priority > :currentPriority AND m.priority <= :newPriority")
+    void decreasePriorityBetween(@Param("currentPriority") Long currentPriority,@Param("newPriority") Long newPriority);
+
+    @Modifying
+    @Query("UPDATE MenuList m SET m.priority = m.priority + 1 WHERE m.priority < :currentPriority AND m.priority >= :newPriority")
+    void increasePriorityBetween(@Param("currentPriority") Long currentPriority, @Param("newPriority") Long newPriority);
+    @Query("SELECT COALESCE(MAX(m.priority), 0) FROM MenuList m WHERE m.user.id = :userId")
+    Optional<Long> findMaxPriorityByUserId(@Param("userId") Long userId);
+
+    @Modifying
+    @Query("UPDATE MenuList m SET m.priority = m.priority - 1 WHERE m.priority > :currentPriority")
+    void decreasePriorityGreaterThan(@Param("currentPriority") Long currentPriority);
 
 }

--- a/src/main/java/com/ourMenu/backend/domain/menulist/domain/MenuList.java
+++ b/src/main/java/com/ourMenu/backend/domain/menulist/domain/MenuList.java
@@ -69,4 +69,9 @@ public class MenuList {
     public void removeMenu(Menu menu) {
         menus.remove(menu);
     }
+
+    public void softDelete() {
+        this.status = Status.DELETED;
+        this.priority = null;
+    }
 }

--- a/src/main/java/com/ourMenu/backend/domain/menulist/dto/response/GetMenuListResponse.java
+++ b/src/main/java/com/ourMenu/backend/domain/menulist/dto/response/GetMenuListResponse.java
@@ -10,4 +10,5 @@ public class GetMenuListResponse {
     private Long menuCount;
     private String imgUrl;
     private String iconType;
+    private Long priority;
 }

--- a/src/main/java/com/ourMenu/backend/domain/menulist/dto/response/MenuListResponseDTO.java
+++ b/src/main/java/com/ourMenu/backend/domain/menulist/dto/response/MenuListResponseDTO.java
@@ -10,4 +10,5 @@ public class MenuListResponseDTO {
     private String title;
     private String imgUrl;
     private String iconType;
+    private Long priority;
 }


### PR DESCRIPTION
### ✏️ 작업 개요
메뉴판 우선순위 반영 및 API 구현

### ⛳ 작업 분류
- [x] 작업1 메뉴판 생성, 수정 및 조회 시 우선순위를 response에 반영
- [x] 작업2 메뉴판의 우선순위 조정 API 구현

### 🔨 작업 상세 내용
  1. 

### 💡 생각해볼 문제
- 우선순위를 기존 API에 반영하긴 했는데 필요하지 않다면 다시 복구해도 될 것 같습니다.
- 메뉴판의 DELETE 기능이 STATUS 및 우선순위만 변경하고, 이미지 혹은 메뉴판 내의 메뉴들의 삭제와 같은 구현이 되어있지 않아 작업할 예정입니다. (이미지 UPDATE 경우 S3파일 삭제 또한 미구현)
