### PR TITLE
Fix/account

### DIFF
--- a/src/main/java/com/ourMenu/backend/domain/user/api/request/ChangePasswordRequest.java
+++ b/src/main/java/com/ourMenu/backend/domain/user/api/request/ChangePasswordRequest.java
@@ -8,9 +8,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ChangePasswordRequest {
 
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*(),.?\":{}|<>])[A-Za-z\\d!@#$%^&*(),.?\":{}|<>]{8,}$", message = "비밀번호의 형식이 올바르지 않습니다")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$", message = "비밀번호의 형식이 올바르지 않습니다")
     private String password;
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*(),.?\":{}|<>])[A-Za-z\\d!@#$%^&*(),.?\":{}|<>]{8,}$", message = "비밀번호의 형식이 올바르지 않습니다")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$", message = "비밀번호의 형식이 올바르지 않습니다")
     private String newPassword;
 
 }

--- a/src/main/java/com/ourMenu/backend/domain/user/api/request/LoginRequest.java
+++ b/src/main/java/com/ourMenu/backend/domain/user/api/request/LoginRequest.java
@@ -11,7 +11,7 @@ public class LoginRequest {
 
     @Email(message = "이메일 형식이 아닙니다")
     private String email;
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*(),.?\":{}|<>])[A-Za-z\\d!@#$%^&*(),.?\":{}|<>]{8,}$", message = "비밀번호의 형식이 올바르지 않습니다")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$", message = "비밀번호의 형식이 올바르지 않습니다")
     private String password;
 
 }

--- a/src/main/java/com/ourMenu/backend/domain/user/api/request/SignUpRequest.java
+++ b/src/main/java/com/ourMenu/backend/domain/user/api/request/SignUpRequest.java
@@ -14,7 +14,7 @@ public class SignUpRequest {
 
     @Email(message = "이메일 형식이 아닙니다")
     private String email;
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*(),.?\":{}|<>])[A-Za-z\\d!@#$%^&*(),.?\":{}|<>]{8,}$", message = "비밀번호의 형식이 올바르지 않습니다")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$", message = "비밀번호의 형식이 올바르지 않습니다")
     private String password;
     @Size(min = 1, max = 6, message = "닉네임은 1글자 이상, 최대 6글자까지 가능합니다")
     private String nickname;

--- a/src/main/java/com/ourMenu/backend/domain/user/domain/User.java
+++ b/src/main/java/com/ourMenu/backend/domain/user/domain/User.java
@@ -25,12 +25,15 @@ public class User {
     private String nickname;
     private String password;
 
+    @Column(name = "created_at", updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private LocalDateTime createdAt;
+    @Column(name = "modified_at", insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
     private LocalDateTime modifiedAt;
 
     private String email;
 
     @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "ENUM('CREATED', 'DELETED', 'UPDATED') DEFAULT 'CREATED'")
     @Builder.Default
     private Status status = Status.CREATED;
 

--- a/src/main/java/com/ourMenu/backend/global/util/JwtProvider.java
+++ b/src/main/java/com/ourMenu/backend/global/util/JwtProvider.java
@@ -29,10 +29,18 @@ public class JwtProvider {
             Jws<Claims> claims = Jwts.parserBuilder()
                     .setSigningKey(secretKey).build()
                     .parseClaimsJws(token);
+            Object userId = claims.getBody().get("userId");
+
+            if(userId instanceof Integer) {
+                return ((Integer) userId).longValue();
+            } else if (userId instanceof Long) {
+                return (Long) userId;
+            } else {
+                throw new JwtException("");
+            }
         } catch(JwtException | IllegalArgumentException e) {
             throw new JwtException("");
         }
-        return 1L;
     }
 
     public boolean isValidToken(String token) {


### PR DESCRIPTION
### ✏️ 작업 개요
jwt 버그 수정
user 관련 수정

### ⛳ 작업 분류
- [x] jwt provider 아이디 매핑 1만 되던 버그 수정
- [x] user password regex 수정 -> 영어 숫자로만 8글자 이상
- [x] user entity 클래스 수정

### 🔨 작업 상세 내용
  1. user entity에서 createdAt, updatedAt 타임스탬프가 제대로 찍히지 않던 부분 수정
  2. user entity status 값이 디폴트로 created로 설정되지 않던 오류 수정

