### PR TITLE
feat: 메뉴 조회 API 기능 개선 (페이징, 가격/태그 검색, 중복 제거)

### DIFF
--- a/src/main/java/com/ourMenu/backend/domain/menu/api/MenuApiController.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/api/MenuApiController.java
@@ -15,6 +15,9 @@ import com.ourMenu.backend.global.exception.ErrorResponse;
 import com.ourMenu.backend.global.util.ApiUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -42,20 +45,42 @@ public class MenuApiController {
     }
 
     // 전체 조회
-    @GetMapping("")
-    public ApiResponse<List<MenuDto>> getAllMenu(@RequestParam(required = false) String title,
-                                              @RequestParam(required = false) String tag,
-                                              @RequestParam(required = false) Integer menuFolderId, @UserId Long userId) {
-        List<MenuDto> menusByCriteria = menuService.getAllMenusByCriteria(title, tag, menuFolderId, userId);
+//    @GetMapping("")
+//    public ApiResponse<List<MenuDto>> getAllMenu(@RequestParam(required = false) String title,
+//                                              @RequestParam(required = false) String tag,
+//                                              @RequestParam(required = false) Integer menuFolderId, @UserId Long userId) {
+//        List<MenuDto> menusByCriteria = menuService.getAllMenusByCriteria(title, tag, menuFolderId, userId);
+//
+//        return ApiUtils.success(menusByCriteria);
+//    }
 
-        return ApiUtils.success(menusByCriteria);
+    @GetMapping("")
+    public ApiResponse<List<MenuDto>> getAllMenu(
+            @RequestParam(required = false) String title,
+            @RequestParam(required = false) String[] tags, // 태그를 배열로 받도록 수정
+            @RequestParam(required = false) Integer menuFolderId,
+            @RequestParam(defaultValue = "0") int page, // 페이지 번호, 기본값은 0
+            @RequestParam(defaultValue = "5") int size, // 페이지 크기, 기본값은 5
+            @RequestParam int minPrice, // 최소 가격
+            @RequestParam int maxPrice, // 최대 가격
+            @UserId Long userId) {
+
+        // Pageable 객체 생성
+        Pageable pageable = PageRequest.of(page, size);
+
+        // 서비스 호출
+        Page<MenuDto> menusByCriteria = menuService.getAllMenusByCriteria2(title, tags, menuFolderId, userId, minPrice, maxPrice, pageable);
+
+        log.info("난 하지 못해 이 것");
+        // ApiResponse로 반환
+        return ApiUtils.success(menusByCriteria.getContent());
     }
 
 
     // 특정 메뉴 조회
     @GetMapping("/{groupId}")
-    public ApiResponse<List<MenuDto>> getMenu(@UserId Long userId, @PathVariable Long groupId) {
-        List<MenuDto> certainMenu = menuService.getCertainMenu(userId, groupId);
+    public ApiResponse<MenuDetailDto> getMenu(@UserId Long userId, @PathVariable Long groupId) {
+        MenuDetailDto certainMenu = menuService.getCertainMenu(userId, groupId);
 
         return ApiUtils.success(certainMenu);
     }
@@ -74,28 +99,6 @@ public class MenuApiController {
         menuService.createMenuImage(photoRequest, userId);
         return ApiUtils.success("OK");
     }
-
-//    @GetMapping("")
-//    public ApiResponse<List<MenuDto>> getMenu(
-//            @RequestParam(required = false) String menuTitle,
-//            @RequestParam(required = false) String menuTag,
-//            @RequestParam(required = false) Integer menuFolderId,
-//
-//            @UserId Long userId) {
-//
-//
-//        Page<Menu> menuPage = menuRepository.findMenusByCriteria(menuTitle, menuFolderId, userId);
-//
-//        List<MenuDto> menuDtos = MenuDto.toDto(menuPage.getContent());
-//
-//        return ApiUtils.success(menuDtos);
-//    }
-
-
-
-
-
-
 
 
     // 삭제

--- a/src/main/java/com/ourMenu/backend/domain/menu/application/MenuService.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/application/MenuService.java
@@ -3,6 +3,7 @@ package com.ourMenu.backend.domain.menu.application;
 import com.ourMenu.backend.domain.menu.domain.*;
 import com.ourMenu.backend.domain.menu.dao.MenuRepository;
 import com.ourMenu.backend.domain.menu.dto.request.*;
+import com.ourMenu.backend.domain.menu.dto.response.MenuDetailDto;
 import com.ourMenu.backend.domain.menu.dto.response.MenuDto;
 import com.ourMenu.backend.domain.menu.dto.response.PostMenuResponse;
 import com.ourMenu.backend.domain.menu.exception.MenuNotFoundException;
@@ -15,6 +16,9 @@ import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -319,16 +323,44 @@ public class MenuService {
 
     
     @Transactional
-    public List<MenuDto> getCertainMenu(Long userId, Long groupId) {
+    public MenuDetailDto getCertainMenu(Long userId, Long groupId) {
         List<Menu> certainMenu = menuRepository.findCertainMenuByUserIdAndGroupId(userId, groupId);
-
-        return MenuDto.toDto(certainMenu);
+        if (certainMenu.isEmpty()) {
+            throw new RuntimeException("해당하는 메뉴가 없습니다");
+        }
+        return MenuDetailDto.toDto(certainMenu);
     }
 
+//    @Transactional
+//    public List<MenuDto> getAllMenusByCriteria(String title, String tag, Integer menuFolderId, Long userId) {
+//        List<Menu> menus = menuRepository.findingMenusByCriteria(title, tag, menuFolderId, userId);
+//        return MenuDto.toDto(menus); // List<MenuDto> 반환
+//    }
+
     @Transactional
-    public List<MenuDto> getAllMenusByCriteria(String title, String tag, Integer menuFolderId, Long userId) {
-        List<Menu> menus = menuRepository.findingMenusByCriteria(title, tag, menuFolderId, userId);
-        return MenuDto.toDto(menus); // List<MenuDto> 반환
+    public Page<MenuDto> getAllMenusByCriteria2(String title, String[] tags, Integer menuFolderId, Long userId, int minPrice, int maxPrice, Pageable pageable){
+        // 메뉴를 페이징 처리하여 조회
+
+        Integer tagCount = (tags != null && tags.length > 0) ? tags.length : null; // 태그가 없으면 null로 설정
+
+        if (minPrice == 5000) {
+            minPrice = 0; // 기본값: 5,000원 (최소)
+        }
+        if (maxPrice == 50000) {
+            maxPrice = 999999; // 기본값: 무한대 (최대)
+        }
+
+        log.info("가격은 " +minPrice);
+        log.info("가격은 " +maxPrice);
+        Page<Menu> menuPage = menuRepository.findingMenusByCriteria2(title, tags, tagCount, menuFolderId, userId, minPrice, maxPrice, pageable);
+
+
+        log.info("Retrieved menuPage: {}", menuPage.getContent());
+        // Menu 엔티티를 MenuDto로 변환
+        List<MenuDto> menuDtos = MenuDto.toDto(menuPage.getContent());
+
+        // Page<MenuDto> 객체로 변환하여 반환
+        return new PageImpl<>(menuDtos, pageable, menuPage.getTotalElements());
     }
 
     @Transactional

--- a/src/main/java/com/ourMenu/backend/domain/menu/dao/MenuRepository.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/dao/MenuRepository.java
@@ -52,35 +52,45 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
             "JOIN FETCH m.images mi ")        // 메뉴와 메뉴 이미지 조인)           // 특정 메뉴 ID로 필터링
      List<Menu> findMenuWithPlaceAndImages();
 
-    @Query("SELECT DISTINCT m FROM Menu m " +
-            "JOIN FETCH m.place p " +         // 메뉴와 식당 조인
-            "LEFT JOIN FETCH m.images mi " +  // 메뉴와 메뉴 이미지의 LEFT JOIN
-            "JOIN m.tags mt " +               // 중간 테이블을 통해 메뉴 태그 조인
-            "JOIN mt.tag t " +                // 태그 엔티티 조인
-            "WHERE m.user.id = :userId " +    // 유저 아이디 필터
-            "AND m.groupId = :groupId " +      // 그룹 ID 필터
-            "AND (:title IS NULL OR m.title LIKE %:title%) " + // 제목 필터
-            "AND (:tag IS NULL OR t.name LIKE %:tag%) " +       // 태그 필터
-            "AND (:menuFolderId IS NULL OR m.menuList.id = :menuFolderId)") // 메뉴판 필터
-    List<Menu> findMenusByCriteria(@Param("title") String title,
-                                   @Param("tag") String tag,
-                                   @Param("menuFolderId") Integer menuFolderId,
-                                   @Param("userId") Long userId,
-                                   @Param("groupId") Long groupId);
 
-    @Query("SELECT DISTINCT m FROM Menu m " +
-            "JOIN FETCH m.place p " +
-            "LEFT JOIN FETCH m.images mi " +
+
+//    @Query("SELECT DISTINCT m FROM Menu m " +
+//            "JOIN FETCH m.place p " +
+//            "LEFT JOIN FETCH m.images mi " +
+//            "JOIN m.tags mt " +
+//            "JOIN mt.tag t " +
+//            "WHERE m.user.id = :userId " +
+//            "AND (:title IS NULL OR m.title LIKE %:title%) " +
+//            "AND (:tag IS NULL OR t.name LIKE %:tag%) " +
+//            "AND (:menuFolderId IS NULL OR m.menuList.id = :menuFolderId)") // groupId 필터 제거
+//    List<Menu> findingMenusByCriteria(@Param("title") String title,
+//                                   @Param("tag") String tag,
+//                                   @Param("menuFolderId") Integer menuFolderId,
+//                                   @Param("userId") Long userId);
+
+    @Query("SELECT m FROM Menu m " +
             "JOIN m.tags mt " +
             "JOIN mt.tag t " +
             "WHERE m.user.id = :userId " +
             "AND (:title IS NULL OR m.title LIKE %:title%) " +
-            "AND (:tag IS NULL OR t.name LIKE %:tag%) " +
-            "AND (:menuFolderId IS NULL OR m.menuList.id = :menuFolderId)") // groupId 필터 제거
-    List<Menu> findingMenusByCriteria(@Param("title") String title,
-                                   @Param("tag") String tag,
-                                   @Param("menuFolderId") Integer menuFolderId,
-                                   @Param("userId") Long userId);
+            "AND (:menuFolderId IS NULL OR m.menuList.id = :menuFolderId) " +
+            "AND (:minPrice IS NULL OR m.price >= :minPrice) " + // 최소 가격 조건
+            "AND (:maxPrice IS NULL OR m.price <= :maxPrice) " + // 최대 가격 조건
+            "AND (:tags IS NULL OR t.name IN :tags) " + // 태그 조건
+            "GROUP BY m.id " +
+            "HAVING (:tagCount IS NULL OR COUNT(DISTINCT t.name) = :tagCount) " + // tagCount가 null인 경우 조건 무시
+            "ORDER BY m.groupId ASC") // groupId를 기준으로 오름차순 정렬
+    Page<Menu> findingMenusByCriteria2(@Param("title") String title,
+                                       @Param("tags") String[] tags, // 태그 배열
+                                       @Param("tagCount") Integer tagCount, // 태그 개수
+                                       @Param("menuFolderId") Integer menuFolderId,
+                                       @Param("userId") Long userId,
+                                       @Param("minPrice") int minPrice,
+                                       @Param("maxPrice") int maxPrice,
+                                       Pageable pageable);
+
+
+
 
 
 

--- a/src/main/java/com/ourMenu/backend/domain/menu/dto/response/MenuDetailDto.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/dto/response/MenuDetailDto.java
@@ -1,0 +1,72 @@
+package com.ourMenu.backend.domain.menu.dto.response;
+
+import com.ourMenu.backend.domain.menu.domain.Menu;
+import com.ourMenu.backend.domain.menu.domain.MenuImage;
+import com.ourMenu.backend.domain.menulist.domain.MenuList;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Data
+@Builder
+public class MenuDetailDto {
+    private Long groupId;
+    private String menuTitle;
+    private int price;
+    private String memo;
+    private String icon;
+    private List<TagDTO> tags;
+    private List<MenuImageDto> images; // 이미지 리스트
+    private List<PlaceMenuFolderDTO> menuFolder; // 메뉴 폴더 리스트
+
+    // DTO 변환 메서드
+    public static MenuDetailDto toDto(List<Menu> menus) {
+
+        List<MenuList> menuLists = new ArrayList<>();
+
+        for (Menu menu : menus) {
+            menuLists.add(menu.getMenuList());
+        }
+
+        List<PlaceMenuFolderDTO> folderDTOs = menuLists.stream() // 메뉴의 폴더 리스트
+                .map(menuList -> new PlaceMenuFolderDTO(menuList.getTitle(), menuList.getIconType())) // 폴더 DTO 변환
+                .distinct() // 중복 제거
+                .collect(Collectors.toList());
+
+
+        MenuDetailDto menuDetailDto = fromMenu(menus.get(0), folderDTOs);
+
+
+        return menuDetailDto;
+    }
+
+
+
+    private static MenuDetailDto fromMenu(Menu menu, List<PlaceMenuFolderDTO> menuFolders) {
+        List<TagDTO> tagDTOs = menu.getTags().stream() // MenuTag 리스트로부터 스트림 생성
+                .map(menuTag -> TagDTO.fromTag(menuTag)) // MenuTag를 TagDTO로 변환
+                .collect(Collectors.toList());
+
+        List<MenuImageDto> imageDTOs = menu.getImages().stream()
+                .map(img -> new MenuImageDto(img.getUrl())) // 이미지 DTO 변환
+                .collect(Collectors.toList());
+
+        return MenuDetailDto.builder()
+                .groupId(menu.getGroupId()) // 메뉴 ID 추가
+                .menuTitle(menu.getTitle())
+                .price(menu.getPrice())
+                .memo(menu.getMemo()) // 메모 추가
+                .icon(menu.getIcon()) // 아이콘 추가
+                .tags(tagDTOs) // 태그 리스트 추가
+                .images(imageDTOs) // 이미지 리스트 추가
+                .menuFolder(menuFolders)
+                .build();
+    }
+}
+
+

--- a/src/main/java/com/ourMenu/backend/domain/menu/dto/response/PlaceMenuFolderDTO.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/dto/response/PlaceMenuFolderDTO.java
@@ -1,10 +1,12 @@
 package com.ourMenu.backend.domain.menu.dto.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
+@AllArgsConstructor
 public class PlaceMenuFolderDTO {
     private String menuFolderTitle;
     private String menuIcon;

--- a/src/main/java/com/ourMenu/backend/domain/menu/dto/response/TagDTO.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/dto/response/TagDTO.java
@@ -1,5 +1,7 @@
 package com.ourMenu.backend.domain.menu.dto.response;
 
+import com.ourMenu.backend.domain.menu.domain.MenuTag;
+import com.ourMenu.backend.domain.menu.domain.Tag;
 import lombok.Builder;
 import lombok.Data;
 
@@ -8,4 +10,11 @@ import lombok.Data;
 public class TagDTO {
     private String tagTitle;
     private boolean isCustom;
+
+    public static TagDTO fromTag(MenuTag menuTag) {
+        return TagDTO.builder()
+                .tagTitle(menuTag.getTag().getName()) // MenuTag를 통해 Tag 객체의 title 가져오기
+                .isCustom(menuTag.getTag().getIsCustom()) // MenuTag의 isCustom 값 사용
+                .build();
+    }
 }


### PR DESCRIPTION
### ✏️ 작업 개요
메뉴 조회 시 페이징 기능을 추가한다.
메뉴 금액으로 메뉴를 조회 할 수도 있어야 한다.
메뉴를 검색할 때 태그를 여러 개 입력받을 수 있다.
중복되는 메뉴를 제거한 채 페이징이 가능해야한다.
groupId 순으로 정렬되어 메뉴가 반환되어야 한다.

### ⛳ 작업 분류
- [ ] 중복 데이터 제거 및 페이징 가능
- [ ] 메뉴 금액으로 메뉴 조회 및 정렬 추가
- [ ]  API 스팩 추가, 쿼리 파라미터 추가 

### 🔨 작업 상세 내용
  1. Pageable를 이용해 페이징 기능을 추가하였습니다
  2. 중복이 제거되지 않는 문제가 발생해 서브쿼리, group by, in 절을 통해 중복되지 발생하지 않은 채로 페이징을 수행합니다.
  3. 여러 태그들 가지고 검색할 수 있도록 쿼리에 having 절을 추가해 검색이 가능하도록 하였습니다.
  4. groupId 순으로 출력하도록 쿼리에 ORDER BY 추가하였습니다.
  5. 상세 메뉴 조회에서 메뉴가 등록된 여러 개의 메뉴판, 이미지, 태그들을 보여지도록 MenuDetailDto API 스팩 추가하였습니다. 

### 💡 생각해볼 문제
- 두 명의 유저로 2개 메뉴판 2개씩 메뉴를 등록하고 태그, 메뉴판, 금액, 제목 등 조건으로 정상적으로 동작하는지 확인해 보았습니다.
![test](https://github.com/user-attachments/assets/b62b75eb-e422-47c0-b3e0-4275d68616b0)