### PR TITLE
유저 지도 검색 API

### DIFF
--- a/src/main/java/com/ourMenu/backend/domain/menu/api/MenuApiController.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/api/MenuApiController.java
@@ -139,8 +139,15 @@ public class MenuApiController {
 
 
         List<MapMenuDTO> response = menus.stream().map(menu ->{
-                int menuFolderCount = menuService.getAllMenusByGroupIdAndUserId(menu.getGroupId(), userId).size() - 1;
+//                int menuFolderCount = menuService.getAllMenusByGroupIdAndUserId(menu.getGroupId(), userId).size() - 1;
+            List<Menu> menuByGroupId = menuService.getAllMenusByGroupIdAndUserId(menu.getGroupId(), userId);
 
+            Menu filteredMenu = menus.stream()
+                    .filter(m -> !"기본 메뉴판".equals(m.getTitle()))
+                    .findFirst()
+                    .orElse(menus.get(0)); // "기본 메뉴판"이 아닌 메뉴가 없으면 첫 번째 메뉴 사용
+
+            int menuFolderCount = menuByGroupId.size() -1;
 
                 return MapMenuDTO.builder()
 //                        .menuId(menu.getId())

--- a/src/main/java/com/ourMenu/backend/domain/menu/api/MenuApiController.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/api/MenuApiController.java
@@ -134,27 +134,23 @@ public class MenuApiController {
 
 
     @GetMapping("/place/{placeId}")
-    public ApiResponse<List<PlaceMenuDTO>> findMenuByPlace(@PathVariable Long placeId, @UserId Long userId) {
+    public ApiResponse<List<MapMenuDTO>> findMenuByPlace(@PathVariable Long placeId, @UserId Long userId) {
         List<Menu> menus = menuService.findMenuByPlace(placeId, userId);
 
-        int menuFolderCount = 0;
+
+        List<MapMenuDTO> response = menus.stream().map(menu ->{
+                int menuFolderCount = menuService.getAllMenusByGroupIdAndUserId(menu.getGroupId(), userId).size() - 1;
 
 
-        List<PlaceMenuDTO> response = menus.stream().map(menu ->{
-                List<PlaceMenuFolderDTO> menuFolders = menuService.getAllMenusByGroupIdAndUserId(menu.getGroupId(), userId).stream().map(m ->
-                    PlaceMenuFolderDTO.builder()
-                            .menuFolderTitle(m.getMenuList().getTitle())
-                            .menuFolderIcon(m.getMenuList().getIconType())
-                            .build()
-                      ).collect(Collectors.toList());
-
-
-                return PlaceMenuDTO.builder()
+                return MapMenuDTO.builder()
 //                        .menuId(menu.getId())
                         .groupId(menu.getGroupId())
                         .menuTitle(menu.getTitle())
                         .menuPrice(menu.getPrice())
                         .menuIconType(menu.getMenuIconType())
+                        .placeTitle(menu.getPlace().getTitle())
+                        .latitude(menu.getPlace().getLatitude())
+                        .longitude(menu.getPlace().getLongitude())
                         .menuTags(menu.getTags().stream().map(tag ->
                                 TagDTO.builder()
                                         .tagTitle(tag.getTag().getName())
@@ -168,8 +164,13 @@ public class MenuApiController {
                                                 .build())
                                 .collect(Collectors.toList())
                         )
-                        .menuFolders(menuFolders)
-                        .menuFolderCount(menuFolders.size() - 1)
+                        .menuFolder(
+                                MapMenuFolderDTO.builder()
+                                        .menuFolderTitle(menu.getMenuList().getTitle())
+                                        .menuFolderIcon(menu.getMenuList().getIconType())
+                                        .menuFolderCount(menuFolderCount)
+                                        .build()
+                        )
                         .build();
         }).collect(Collectors.toList());
 

--- a/src/main/java/com/ourMenu/backend/domain/menu/api/PlaceController.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/api/PlaceController.java
@@ -27,12 +27,13 @@ public class PlaceController {
     private final PlaceService placeService;
     private final MenuService menuService;
 
-    @GetMapping("/place")
-    public ApiResponse<List<GetPlaceResponse>> GetPlace(@UserId Long userId){
-        List<Place> placeList = placeService.findPlacesByUserId(userId);
-        List<GetPlaceResponse> getPlaceResponseList = placeList.stream().map(GetPlaceResponse::toDto).toList();
-        return ApiUtils.success(getPlaceResponseList);
-    }
+    // "/map" 으로 변경
+//    @GetMapping("/place")
+//    public ApiResponse<List<GetPlaceResponse>> GetPlace(@UserId Long userId){
+//        List<Place> placeList = placeService.findPlacesByUserId(userId);
+//        List<GetPlaceResponse> getPlaceResponseList = placeList.stream().map(GetPlaceResponse::toDto).toList();
+//        return ApiUtils.success(getPlaceResponseList);
+//    }
 
     @GetMapping("")
     public ApiResponse<List<MenuPlaceDTO>> getPlaceMenu(@UserId Long userId){

--- a/src/main/java/com/ourMenu/backend/domain/menu/api/PlaceController.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/api/PlaceController.java
@@ -64,4 +64,19 @@ public class PlaceController {
 
         return ApiUtils.success(response);
     }
+
+    @GetMapping("/search-history")
+    public ApiResponse<List<MenuSearchDTO>> getSearchHistory(@UserId Long userId){
+        List<Menu> searchHistory = placeService.findSearchHistory(userId);
+        List<MenuSearchDTO> response = searchHistory.stream().map(menu ->
+                MenuSearchDTO.builder()
+                        .groupId(menu.getGroupId())
+                        .menuTitle(menu.getTitle())
+                        .placeTitle(menu.getPlace().getTitle())
+                        .placeAddress(menu.getPlace().getAddress())
+                        .build()
+        ).collect(Collectors.toList());
+
+        return ApiUtils.success(response);
+    }
 }

--- a/src/main/java/com/ourMenu/backend/domain/menu/api/PlaceController.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/api/PlaceController.java
@@ -78,9 +78,14 @@ public class PlaceController {
     @GetMapping("/{groupId}")
     public ApiResponse<MapMenuDTO> getMenuInfo(@PathVariable Long groupId, @UserId Long userId){
         List<Menu> menus = menuService.getAllMenusByGroupIdAndUserId(groupId, userId);
-        Menu menu = menus.get(0);
 
-        int menuFolderCount = (int) menus.stream().count() - 1;
+        // "기본 메뉴판"이 아닌 첫 번째 메뉴를 찾기
+        Menu menu = menus.stream()
+                .filter(m -> !"기본 메뉴판".equals(m.getTitle()))
+                .findFirst()
+                .orElse(menus.get(0)); // "기본 메뉴판"이 아닌 메뉴가 없으면 첫 번째 메뉴 사용
+
+        int menuFolderCount = menus.size() - 1;
 
 //        List<PlaceMenuFolderDTO> menuFolders = new ArrayList<>();
 //        for (Menu menu : menus) {

--- a/src/main/java/com/ourMenu/backend/domain/menu/api/PlaceController.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/api/PlaceController.java
@@ -1,20 +1,14 @@
 package com.ourMenu.backend.domain.menu.api;
 
-import com.ourMenu.backend.domain.menu.api.response.GetPlaceResponse;
 import com.ourMenu.backend.domain.menu.application.MenuService;
 import com.ourMenu.backend.domain.menu.application.PlaceService;
 import com.ourMenu.backend.domain.menu.domain.Menu;
-import com.ourMenu.backend.domain.menu.domain.Place;
-import com.ourMenu.backend.domain.menu.dto.response.MenuPlaceDTO;
-import com.ourMenu.backend.domain.menu.dto.response.MenuSearchDTO;
+import com.ourMenu.backend.domain.menu.dto.response.*;
 import com.ourMenu.backend.global.argument_resolver.UserId;
 import com.ourMenu.backend.global.common.ApiResponse;
 import com.ourMenu.backend.global.util.ApiUtils;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -77,6 +71,59 @@ public class PlaceController {
                         .placeAddress(menu.getPlace().getAddress())
                         .build()
         ).collect(Collectors.toList());
+
+        return ApiUtils.success(response);
+    }
+
+    @GetMapping("/{groupId}")
+    public ApiResponse<MapMenuDTO> getMenuInfo(@PathVariable Long groupId, @UserId Long userId){
+        List<Menu> menus = menuService.getAllMenusByGroupIdAndUserId(groupId, userId);
+        Menu menu = menus.get(0);
+
+        int menuFolderCount = (int) menus.stream().count() - 1;
+
+//        List<PlaceMenuFolderDTO> menuFolders = new ArrayList<>();
+//        for (Menu menu : menus) {
+//            menuFolders = menuService.getAllMenusByGroupIdAndUserId(menu.getGroupId(), userId).stream().map(m ->
+//                    PlaceMenuFolderDTO.builder()
+//                            .menuFolderTitle(m.getMenuList().getTitle())
+//                            .menuFolderIcon(m.getMenuList().getIconType())
+//                            .build()
+//            ).collect(Collectors.toList());
+//        }
+
+
+//        Menu menu = placeService.findMenuByGroupIdAndUserId(groupId, userId);
+
+
+        MapMenuDTO response = MapMenuDTO.builder()
+                    .groupId(menu.getGroupId())
+                    .menuTitle(menu.getTitle())
+                    .menuPrice(menu.getPrice())
+                    .menuIconType(menu.getMenuIconType())
+                .placeTitle(menu.getPlace().getTitle())
+                .latitude(menu.getPlace().getLatitude())
+                .longitude(menu.getPlace().getLongitude())
+                    .menuTags(menu.getTags().stream().map(tag ->
+                                    TagDTO.builder()
+                                            .tagTitle(tag.getTag().getName())
+                                            .isCustom(tag.getTag().getIsCustom())
+                                            .build())
+                            .collect(Collectors.toList())
+                    )
+                    .menuImgsUrl(menu.getImages().stream().map(image ->
+                                    MenuImageDto.builder() // ImageDTO 클래스에 맞게 수정
+                                            .menuImgUrl(image.getUrl()) // 이미지 URL 필드 예시
+                                            .build())
+                            .collect(Collectors.toList())
+                    )
+                    .menuFolder(
+                            MapMenuFolderDTO.builder()
+                                    .menuFolderTitle(menu.getMenuList().getTitle())
+                                    .menuFolderIcon(menu.getMenuList().getIconType())
+                                    .menuFolderCount(menuFolderCount)
+                                    .build()
+                    ).build();
 
         return ApiUtils.success(response);
     }

--- a/src/main/java/com/ourMenu/backend/domain/menu/application/MenuService.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/application/MenuService.java
@@ -390,9 +390,14 @@ public class MenuService {
             List<Menu> menuList = menuPage.getContent();
             return menuList; // List<MenuDto> 반환
         }
-    @Transactional(readOnly = true)
+    @Transactional
     public List<Menu> getAllMenusByGroupIdAndUserId(Long groupId, Long userId){
-        return menuRepository.findByUserIdAndGroupId(userId, groupId);
+        List<Menu> menuList = menuRepository.findByUserIdAndGroupId(userId, groupId);
+        for (Menu menu : menuList) {
+            menu.updateModifiedAt();
+            menuRepository.save(menu);
+        }
+        return menuList;
 
     }
 
@@ -400,5 +405,9 @@ public class MenuService {
         Menu menu = menuRepository.findByUserIdAndMenuListIdAndGroupId(userId, menuFolderId, groupId)
                 .orElseThrow(() -> new MenuNotFoundException("해당하는 메뉴가 없습니다"));
         return MenuIdDto.toDto(menu);
+    }
+
+    public void updateModifiedAt(Menu menu){
+        menu.updateModifiedAt();
     }
 }

--- a/src/main/java/com/ourMenu/backend/domain/menu/application/PlaceService.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/application/PlaceService.java
@@ -19,9 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -117,18 +115,12 @@ public class PlaceService {
 //                    .orElseThrow(() -> new MenuNotFoundException()));
 //        }
         List<Menu> result = menuRepository.findMenuByTitle(title, userId).orElseThrow(() -> new MenuNotFoundException());
-
-        for (Menu menu : result) {
-            menu.updateModifiedAt();
-        }
-
         return result;
     }
 
-    public List<Menu> findSearchHistory(Long userId){
+    public List<Menu> findSearchHistory(Long userId) {
         Pageable pageable = PageRequest.of(0, 15, Sort.by("modifiedAt").descending());
-        Page<Menu> menus = menuRepository.findByUserIdOrderByModifiedAt(userId, pageable);
-        List<Menu> recentMenus = menus.getContent();
-        return recentMenus;
+        List<Menu> menus = menuRepository.findDistinctByUserIdOrderByModifiedAtDesc(userId, pageable);
+        return menus;
     }
 }

--- a/src/main/java/com/ourMenu/backend/domain/menu/application/PlaceService.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/application/PlaceService.java
@@ -11,6 +11,10 @@ import com.ourMenu.backend.domain.user.application.UserService;
 import com.ourMenu.backend.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -114,6 +118,17 @@ public class PlaceService {
 //        }
         List<Menu> result = menuRepository.findMenuByTitle(title, userId).orElseThrow(() -> new MenuNotFoundException());
 
+        for (Menu menu : result) {
+            menu.updateModifiedAt();
+        }
+
         return result;
+    }
+
+    public List<Menu> findSearchHistory(Long userId){
+        Pageable pageable = PageRequest.of(0, 15, Sort.by("modifiedAt").descending());
+        Page<Menu> menus = menuRepository.findByUserIdOrderByModifiedAt(userId, pageable);
+        List<Menu> recentMenus = menus.getContent();
+        return recentMenus;
     }
 }

--- a/src/main/java/com/ourMenu/backend/domain/menu/dao/MenuRepository.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/dao/MenuRepository.java
@@ -97,5 +97,11 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
             "GROUP BY m2.groupId)")
     Optional<List<Menu>> findMenuByTitle(@Param("title") String title, @Param("userId") Long userId);
 
-    Page<Menu> findByUserIdOrderByModifiedAt(Long userId, Pageable pageable);
+//    Page<Menu> findByUserIdOrderByModifiedAt(Long userId, Pageable pageable);
+
+    @Query("SELECT m FROM Menu m WHERE m.user.id = :userId AND m.modifiedAt = (" +
+            "SELECT MAX(subM.modifiedAt) FROM Menu subM WHERE subM.groupId = m.groupId AND subM.user.id = :userId" +
+            ") ORDER BY m.modifiedAt DESC")
+    List<Menu> findDistinctByUserIdOrderByModifiedAtDesc(@Param("userId") Long userId, Pageable pageable);
+
 }

--- a/src/main/java/com/ourMenu/backend/domain/menu/dao/MenuRepository.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/dao/MenuRepository.java
@@ -97,4 +97,5 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
             "GROUP BY m2.groupId)")
     Optional<List<Menu>> findMenuByTitle(@Param("title") String title, @Param("userId") Long userId);
 
+    Page<Menu> findByUserIdOrderByModifiedAt(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/ourMenu/backend/domain/menu/domain/Menu.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/domain/Menu.java
@@ -72,10 +72,10 @@ public class Menu {
 //        this.status = (this.status == null) ? MenuStatus.CREATED : this.status;
 //    }
 
-    @PreUpdate
-    public void preUpdate() {
-        this.modifiedAt = LocalDateTime.now();
-    }
+//    @PreUpdate
+//    public void preUpdate() {
+//        this.modifiedAt = LocalDateTime.now();
+//    }
 
     public void addMenuImage(MenuImage menuImage) {
         //System.out.println("menuImage = " + menuImage);
@@ -145,5 +145,9 @@ public class Menu {
 
     public void changeIcon(String icon) {
         this.menuIconType = icon;
+    }
+
+    public void updateModifiedAt(){
+        this.modifiedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/ourMenu/backend/domain/menu/dto/response/MapMenuDTO.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/dto/response/MapMenuDTO.java
@@ -7,14 +7,16 @@ import java.util.List;
 
 @Data
 @Builder
-public class PlaceMenuDTO {
+public class MapMenuDTO {
 //    private Long menuId;
     private Long groupId;
     private String menuTitle;
     private int menuPrice;
     private String menuIconType;
+    private String placeTitle;
+    private Double latitude;
+    private Double longitude;
     private List<TagDTO> menuTags;
     private List<MenuImageDto> menuImgsUrl;
-    private List<PlaceMenuFolderDTO> menuFolders;
-    private int menuFolderCount;
+    private MapMenuFolderDTO menuFolder;
 }

--- a/src/main/java/com/ourMenu/backend/domain/menu/dto/response/MapMenuFolderDTO.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/dto/response/MapMenuFolderDTO.java
@@ -1,0 +1,14 @@
+package com.ourMenu.backend.domain.menu.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class MapMenuFolderDTO {
+    private String menuFolderTitle;
+    private String menuFolderIcon;
+    private int menuFolderCount;
+}


### PR DESCRIPTION
### ✏️ 작업 개요
유저 지도 검색 API 구현

### ⛳ 작업 분류
- [ ] 작업1 GET /menu/place/{placeId} 수정
- [ ] 작업2 GET /map/{groupId} 구현
- [ ] 작업3 GET /map/search-history 구현

### 🔨 작업 상세 내용
  1. 최근 검색어를  찾기 위해 menu 중 modifiedAt을 검색 시점에서 갱신하고, 이를 정렬하여 최근에 검색한 메뉴를 반환해줍니다.

### 💡 생각해볼 문제
- 생각해볼 내용을 적습니다
