### PR TITLE
Fix/article

### DIFF
--- a/src/main/java/com/ourMenu/backend/domain/article/application/ArticleService.java
+++ b/src/main/java/com/ourMenu/backend/domain/article/application/ArticleService.java
@@ -130,22 +130,17 @@ public class ArticleService {
             throw new RuntimeException("권한이 없습니다");
         }
 
-        // 기존 ArticleMenu 삭제
         findArticle.getArticleMenuList().forEach(articleMenu -> {
-            articleMenu.deleteArticle();  // Article과의 관계 끊기
-            articleMenuRepository.delete(articleMenu);  // ArticleMenu 삭제
+            articleMenu.deleteArticle();
+            articleMenuRepository.delete(articleMenu);
         });
 
-        em.flush();  // 삭제된 내용을 즉시 반영
-
-        // findArticle의 ArticleMenu 리스트 비우기
         findArticle.deleteAllArticleMenus();
 
-
         for (ArticleMenu articleMenu : article.getArticleMenuList()) {
-            ArticleMenu saveArticleMenu = articleMenuService.save(articleMenu);
-            findArticle.addArticleMenu(saveArticleMenu);
-            saveArticleMenu.confirmArticle(findArticle);
+            findArticle.addArticleMenu(articleMenu);
+            articleMenu.confirmArticle(findArticle);
+            articleMenuService.save(articleMenu);
         }
         findArticle.update(article);
         return findArticle;

--- a/src/main/java/com/ourMenu/backend/domain/article/domain/Article.java
+++ b/src/main/java/com/ourMenu/backend/domain/article/domain/Article.java
@@ -56,8 +56,12 @@ public class Article {
 
     public void addArticleMenu(ArticleMenu articleMenu) {
         this.articleMenuList.add(articleMenu);
-        menuCount++;
     }
+
+    public void upMenuCount(){
+        this.menuCount++;
+    }
+
 
     public void setStatus(Status status) {
         this.status = status;
@@ -75,7 +79,7 @@ public class Article {
     }
 
     public void deleteAllArticleMenus() {
-        this.articleMenuList = new ArrayList<>();
+        articleMenuList.clear();
         menuCount = 0;
     }
 }

--- a/src/main/java/com/ourMenu/backend/domain/article/domain/ArticleMenu.java
+++ b/src/main/java/com/ourMenu/backend/domain/article/domain/ArticleMenu.java
@@ -37,6 +37,10 @@ public class ArticleMenu {
 
     public void confirmArticle(Article article){
         this.article = article;
-        article.addArticleMenu(this);
+        article.upMenuCount();
+    }
+
+    public void deleteArticle(){
+        this.article = null;
     }
 }


### PR DESCRIPTION
### ✏️ 작업 개요
 - #92 
### ⛳ 작업 분류
- [x] update 버그 해결
- [x] save 버그 해결
- [ ] 테스트 코드 작성

### 🔨 작업 상세 내용
  1. 불필요한 쿼리 수를 최대한 줄였습니다.
  

### 💡 생각해볼 문제
- #41 에 관련된 내용인데 delete하고 update하는 로직에 em.flush를 꼭 해야하는 이유가 납득이 되지 않았는데 동일한 문제점을 겪었습니다.
- flush 문제는 아니고, 양방향 연관관계를 온전하게 끊어 줘야 entitymanger 입장에서 삭제된 엔티티로 인지하네요
- 이외에도 예상하지 못한 문제(cascade를 설정하지 않았음에도 내부 엔티티가 저장되는 문제)가 있었는데 JPA 어렵네요 😢 
