### PR TITLE
fix: 태그 없는 메뉴 조회 안 되는 문제 해결 및 운영정보 글자수 확장

### DIFF
--- a/mysql/init/init.sql
+++ b/mysql/init/init.sql
@@ -91,7 +91,7 @@ create table place (
                        place_id bigint not null auto_increment,
                        user_id bigint,
                        address varchar(255),
-                       info varchar(255),
+                       info varchar(500),
                        title varchar(255),
                        status enum ('CREATED','DELETED','UPDATED'),
                        primary key (place_id)

--- a/src/main/java/com/ourMenu/backend/domain/menu/application/MenuService.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/application/MenuService.java
@@ -332,11 +332,10 @@ public class MenuService {
 
     @Transactional
     public MenuDetailDto getCertainMenu(Long userId, Long groupId) {
-        List<Menu> certainMenu = menuRepository.findCertainMenuByUserIdAndGroupId(userId, groupId);
-        if (certainMenu.isEmpty()) {
-            throw new RuntimeException("해당하는 메뉴가 없습니다");
-        }
-        return MenuDetailDto.toDto(certainMenu);
+        List<Menu> menu = menuRepository.findCertainMenuByUserIdAndGroupId(userId, groupId)
+                .orElseThrow(() -> new RuntimeException("해당하는 메뉴가 없습니다."));
+
+        return MenuDetailDto.toDto(menu);
     }
 
 //    @Transactional

--- a/src/main/java/com/ourMenu/backend/domain/menu/dao/MenuRepository.java
+++ b/src/main/java/com/ourMenu/backend/domain/menu/dao/MenuRepository.java
@@ -35,14 +35,11 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
 
     Optional<Menu> findByIdAndUserId(Long menuId, Long userId);
 
-    @Query("SELECT DISTINCT m FROM Menu m " +
-            "JOIN FETCH m.place p " +
-            "LEFT JOIN FETCH m.images mi " +
-            "JOIN m.tags mt " +
-            "JOIN mt.tag t " +
-            "WHERE m.user.id = :userId " +
-            "AND m.groupId = :groupId")
-    List<Menu> findCertainMenuByUserIdAndGroupId(@Param("userId") Long userId,
+    @Query("SELECT m FROM Menu m WHERE m.id IN (" +
+            "(SELECT MIN(m2.id) FROM Menu m2 WHERE m2.user.id = :userId " +
+            "AND m2.groupId = :groupId " + // groupId를 조건에 추가
+            "GROUP BY m2.groupId))")
+    Optional<List<Menu>> findCertainMenuByUserIdAndGroupId(@Param("userId") Long userId,
                                                  @Param("groupId") Long groupId);
 
 
@@ -67,8 +64,8 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
             "SELECT MIN(m2.id) FROM Menu m2 " +
             "JOIN m2.place p " +
             "LEFT JOIN m2.images mi " +
-            "JOIN m2.tags mt " +
-            "JOIN mt.tag t " +
+            "LEFT JOIN m2.tags mt " +
+            "LEFT JOIN mt.tag t " +
             "WHERE m2.user.id = :userId " +
             "AND (:tags IS NULL OR (t.name IN :tags)) " +
             "AND (:menuFolderId IS NULL OR m2.menuList.id = :menuFolderId) " +


### PR DESCRIPTION
### ✏️ 작업 개요
태그가 없는 경우 메뉴가 조회되지 않은 문제 해결, DB 가게 운영정보 글자수 늘림

### ⛳ 작업 분류
- [ ] 조회 Query 변경 
- [ ] 글자수 추가

### 🔨 작업 상세 내용
  1. 태그가 없는 경우에 메뉴가 조회되지 않는 문제를 LEFT JOIN으로 변경해 해결하였습니다.
  2. 운영시간 정보가 VARCHAR(255) -> 500으로 변경

### 💡 생각해볼 문제
- 예상치도 못한 문제였습니다.
